### PR TITLE
Fix charge controller address issues and more

### DIFF
--- a/Arduino-Version/Multiple-Charge-Controllers/SOLAR_RECEIVE/SOLAR_RECEIVE.ino
+++ b/Arduino-Version/Multiple-Charge-Controllers/SOLAR_RECEIVE/SOLAR_RECEIVE.ino
@@ -1,9 +1,9 @@
 /*
-    Cole L - 20th November 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
+    Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
     
     This is an example to retrieve data from multiple charge controllers. All this program does is print the data to the console.
-	This should give you enough information on how to read the values so you can do more exciting stuff with the data.
-	I would suggest looking into setting up an MQTT server so you can view the data on other devices.
+    This should give you enough information on how to read the values so you can do more exciting stuff with the data.
+    I would suggest looking into setting up an MQTT server so you can view the data on other devices.
     
     This code runs on an ESP8266 NODEMCU 0.9 module.
 */
@@ -58,8 +58,8 @@ const char* chargeModes[7]={
 };
 
 /*
-	Array of fault codes.
-	These are all the possible faults the charge controller can indicate.
+    Array of fault codes.
+    These are all the possible faults the charge controller can indicate.
 */
 const char* faultCodes[15] = {
     "Charge MOS short circuit",     // (16384 | 01000000 00000000)
@@ -120,198 +120,198 @@ int getRealTemp(int temp){
 }
 
 /*
-	Print all the charge controller data to the serial monitor.
+    Print all the charge controller data to the serial monitor.
 */
 void printAllData(int nodeId){
-	Serial.print(F("------------ Data From Node "));
-	Serial.print(nodeId);
-	Serial.println(F(" ------------"));
+    Serial.print(F("------------ Data From Node "));
+    Serial.print(nodeId);
+    Serial.println(F(" ------------"));
 
-	Serial.println(F("------------- Real Time Data -------------"));
+    Serial.println(F("------------- Real Time Data -------------"));
 
-	// Print the charging mode of the charge controller:
-	int loadOffset = *chargeControllerRegisterData[nodeId][32] > 6 ? 32768 : 0;
-	Serial.print(F("Charging Mode:\t\t\t"));
-	Serial.println(chargeModes[*chargeControllerRegisterData[nodeId][32] - loadOffset]);
+    // Print the charging mode of the charge controller:
+    int loadOffset = *chargeControllerRegisterData[nodeId][32] > 6 ? 32768 : 0;
+    Serial.print(F("Charging Mode:\t\t\t"));
+    Serial.println(chargeModes[*chargeControllerRegisterData[nodeId][32] - loadOffset]);
 
-	// Print the battery state of charge:
-	Serial.print(F("Battery SOC:\t\t\t"));
-	Serial.print(*chargeControllerRegisterData[nodeId][0]);
-	Serial.println(F("%"));
+    // Print the battery state of charge:
+    Serial.print(F("Battery SOC:\t\t\t"));
+    Serial.print(*chargeControllerRegisterData[nodeId][0]);
+    Serial.println(F("%"));
 
-	// Print the battery voltage:
-	Serial.print(F("Battery Voltage:\t\t"));
-	Serial.print((*chargeControllerRegisterData[nodeId][1]*0.1));
-	Serial.println(F("V"));
+    // Print the battery voltage:
+    Serial.print(F("Battery Voltage:\t\t"));
+    Serial.print((*chargeControllerRegisterData[nodeId][1]*0.1));
+    Serial.println(F("V"));
 
-	// Print the battery charge current:
-	Serial.print(F("Battery Charge Current:\t\t"));
-	Serial.print((*chargeControllerRegisterData[nodeId][2]*0.01));
-	Serial.println(F("A"));
+    // Print the battery charge current:
+    Serial.print(F("Battery Charge Current:\t\t"));
+    Serial.print((*chargeControllerRegisterData[nodeId][2]*0.01));
+    Serial.println(F("A"));
 
-	// Print the controller temperature:
-	Serial.print(F("Controller Temperature:\t\t"));
-	Serial.print(getRealTemp(*chargeControllerRegisterData[nodeId][3] >> 8));
-	Serial.println(F("*C"));
+    // Print the controller temperature:
+    Serial.print(F("Controller Temperature:\t\t"));
+    Serial.print(getRealTemp(*chargeControllerRegisterData[nodeId][3] >> 8));
+    Serial.println(F("*C"));
 
-	// Print the battery temperature:
-	Serial.print(F("Battery Temperature:\t\t"));
-	Serial.print(getRealTemp(*chargeControllerRegisterData[nodeId][3] & 0xFF));
-	Serial.println(F("*C"));
+    // Print the battery temperature:
+    Serial.print(F("Battery Temperature:\t\t"));
+    Serial.print(getRealTemp(*chargeControllerRegisterData[nodeId][3] & 0xFF));
+    Serial.println(F("*C"));
 
-	// Print the load voltage:
-	Serial.print(F("Load Voltage:\t\t\t"));
-	Serial.print((*chargeControllerRegisterData[nodeId][4]*0.1));
-	Serial.println(F("V"));
+    // Print the load voltage:
+    Serial.print(F("Load Voltage:\t\t\t"));
+    Serial.print((*chargeControllerRegisterData[nodeId][4]*0.1));
+    Serial.println(F("V"));
 
-	// Print the load current:
-	Serial.print(F("Load Current:\t\t\t"));
-	Serial.print((*chargeControllerRegisterData[nodeId][5]*0.01));
-	Serial.println(F("A"));
+    // Print the load current:
+    Serial.print(F("Load Current:\t\t\t"));
+    Serial.print((*chargeControllerRegisterData[nodeId][5]*0.01));
+    Serial.println(F("A"));
 
-	// Print the load power:
-	Serial.print(F("Load Power:\t\t\t"));
-	Serial.print(*chargeControllerRegisterData[nodeId][6]);
-	Serial.println(F("W"));
+    // Print the load power:
+    Serial.print(F("Load Power:\t\t\t"));
+    Serial.print(*chargeControllerRegisterData[nodeId][6]);
+    Serial.println(F("W"));
 
-	// Print the panel volts:
-	Serial.print(F("Panel Volts:\t\t\t"));
-	Serial.print((*chargeControllerRegisterData[nodeId][7]*0.1));
-	Serial.println(F("V"));
+    // Print the panel volts:
+    Serial.print(F("Panel Volts:\t\t\t"));
+    Serial.print((*chargeControllerRegisterData[nodeId][7]*0.1));
+    Serial.println(F("V"));
 
-	// Print the panel amps:
-	Serial.print(F("Panel Amps:\t\t\t"));
-	Serial.print((*chargeControllerRegisterData[nodeId][8]*0.01));
-	Serial.println(F("A"));
+    // Print the panel amps:
+    Serial.print(F("Panel Amps:\t\t\t"));
+    Serial.print((*chargeControllerRegisterData[nodeId][8]*0.01));
+    Serial.println(F("A"));
 
-	// Print the panel power:
-	Serial.print(F("Panel Power: \t\t\t"));
-	Serial.print(*chargeControllerRegisterData[nodeId][9]);
-	Serial.println(F("W"));
+    // Print the panel power:
+    Serial.print(F("Panel Power: \t\t\t"));
+    Serial.print(*chargeControllerRegisterData[nodeId][9]);
+    Serial.println(F("W"));
 
-	Serial.println("--------------- DAILY DATA ---------------");
+    Serial.println("--------------- DAILY DATA ---------------");
 
-	// Print the daily battery minimum voltage:
-	Serial.print(F("Battery Minimum Voltage:\t"));
-	Serial.print((*chargeControllerRegisterData[nodeId][11]*0.1));
-	Serial.println(F("V"));
+    // Print the daily battery minimum voltage:
+    Serial.print(F("Battery Minimum Voltage:\t"));
+    Serial.print((*chargeControllerRegisterData[nodeId][11]*0.1));
+    Serial.println(F("V"));
 
-	// Print the daily battery minimum voltage:
-	Serial.print(F("Battery Maximum Voltage:\t"));
-	Serial.print((*chargeControllerRegisterData[nodeId][12]*0.1));
-	Serial.println(F("V"));
+    // Print the daily battery minimum voltage:
+    Serial.print(F("Battery Maximum Voltage:\t"));
+    Serial.print((*chargeControllerRegisterData[nodeId][12]*0.1));
+    Serial.println(F("V"));
 
-	// Print the daily maximum charge current:
-	Serial.print(F("Maximum Charge Current:\t\t"));
-	Serial.print((*chargeControllerRegisterData[nodeId][13]*0.01));
-	Serial.println(F("A"));
+    // Print the daily maximum charge current:
+    Serial.print(F("Maximum Charge Current:\t\t"));
+    Serial.print((*chargeControllerRegisterData[nodeId][13]*0.01));
+    Serial.println(F("A"));
 
-	// Print the daily maximum load current:
-	Serial.print(F("Maximum Load Discharge Current:\t"));
-	Serial.print((*chargeControllerRegisterData[nodeId][14]*0.01));
-	Serial.println(F("A"));
+    // Print the daily maximum load current:
+    Serial.print(F("Maximum Load Discharge Current:\t"));
+    Serial.print((*chargeControllerRegisterData[nodeId][14]*0.01));
+    Serial.println(F("A"));
 
-	// Print the daily maximum charge power: 
-	Serial.print(F("Maximum Charge Power:\t\t"));
-	Serial.print(*chargeControllerRegisterData[nodeId][15]);
-	Serial.println(F("W"));
+    // Print the daily maximum charge power: 
+    Serial.print(F("Maximum Charge Power:\t\t"));
+    Serial.print(*chargeControllerRegisterData[nodeId][15]);
+    Serial.println(F("W"));
 
-	// Print the daily maximum load power: 
-	Serial.print(F("Maximum Load Discharge Power:\t"));
-	Serial.print(*chargeControllerRegisterData[nodeId][16]);
-	Serial.println(F("W"));
+    // Print the daily maximum load power: 
+    Serial.print(F("Maximum Load Discharge Power:\t"));
+    Serial.print(*chargeControllerRegisterData[nodeId][16]);
+    Serial.println(F("W"));
 
-	// Print the daily charge amp hours:
-	Serial.print(F("Charge Amp Hours:\t\t"));
-	Serial.print(*chargeControllerRegisterData[nodeId][17]);
-	Serial.println(F("Ah"));
+    // Print the daily charge amp hours:
+    Serial.print(F("Charge Amp Hours:\t\t"));
+    Serial.print(*chargeControllerRegisterData[nodeId][17]);
+    Serial.println(F("Ah"));
 
-	// Print the daily load amp hours:
-	Serial.print(F("Load Amp Hours:\t\t\t"));
-	Serial.print(*chargeControllerRegisterData[nodeId][18]);
-	Serial.println(F("Ah"));
+    // Print the daily load amp hours:
+    Serial.print(F("Load Amp Hours:\t\t\t"));
+    Serial.print(*chargeControllerRegisterData[nodeId][18]);
+    Serial.println(F("Ah"));
 
-	// Print the daily charge power:
-	Serial.print(F("Charge Power:\t\t\t"));
-	Serial.print((*chargeControllerRegisterData[nodeId][19]*0.001));
-	Serial.println(F("KWh"));
+    // Print the daily charge power:
+    Serial.print(F("Charge Power:\t\t\t"));
+    Serial.print((*chargeControllerRegisterData[nodeId][19]*0.001));
+    Serial.println(F("KWh"));
 
-	// Print the daily load power:
-	Serial.print(F("Load Power:\t\t\t"));
-	Serial.print((*chargeControllerRegisterData[nodeId][20]*0.001));
-	Serial.println(F("KWh"));
+    // Print the daily load power:
+    Serial.print(F("Load Power:\t\t\t"));
+    Serial.print((*chargeControllerRegisterData[nodeId][20]*0.001));
+    Serial.println(F("KWh"));
 
-	Serial.println(F("------------- LIFETIME DATA --------------"));
+    Serial.println(F("------------- LIFETIME DATA --------------"));
 
-	// Print the number of days operational:
-	Serial.print(F("Days Operational:\t\t"));
-	Serial.print(*chargeControllerRegisterData[nodeId][21]);
-	Serial.println(F("Days"));
+    // Print the number of days operational:
+    Serial.print(F("Days Operational:\t\t"));
+    Serial.print(*chargeControllerRegisterData[nodeId][21]);
+    Serial.println(F("Days"));
 
-	// Print the number of times batteries were over discharged:
-	Serial.print(F("Times Over Discharged:\t\t"));
-	Serial.println(*chargeControllerRegisterData[nodeId][22]);
+    // Print the number of times batteries were over discharged:
+    Serial.print(F("Times Over Discharged:\t\t"));
+    Serial.println(*chargeControllerRegisterData[nodeId][22]);
 
-	// Print the number of times batteries were fully charges:
-	Serial.print(F("Times Fully Charged:\t\t"));
-	Serial.println(*chargeControllerRegisterData[nodeId][23]);
+    // Print the number of times batteries were fully charges:
+    Serial.print(F("Times Fully Charged:\t\t"));
+    Serial.println(*chargeControllerRegisterData[nodeId][23]);
 
-	// Print the cumulative amp hours:
-	Serial.print(F("Cumulative Amp Hours:\t\t"));
-	Serial.print(((*chargeControllerRegisterData[nodeId][24]*65536 + *chargeControllerRegisterData[nodeId][25])*0.001));
-	Serial.println(F("KAh"));
+    // Print the cumulative amp hours:
+    Serial.print(F("Cumulative Amp Hours:\t\t"));
+    Serial.print(((*chargeControllerRegisterData[nodeId][24]*65536 + *chargeControllerRegisterData[nodeId][25])*0.001));
+    Serial.println(F("KAh"));
 
-	// Print the cumulative load amp hours:
-	Serial.print(F("Load Amp Hours:\t\t\t"));
-	Serial.print(((*chargeControllerRegisterData[nodeId][26]*65536 + *chargeControllerRegisterData[nodeId][27])*0.001));
-	Serial.println(F("KAh"));
+    // Print the cumulative load amp hours:
+    Serial.print(F("Load Amp Hours:\t\t\t"));
+    Serial.print(((*chargeControllerRegisterData[nodeId][26]*65536 + *chargeControllerRegisterData[nodeId][27])*0.001));
+    Serial.println(F("KAh"));
 
-	// Print the cumulative power hours:
-	Serial.print(F("Cumulative Power:\t\t"));
-	Serial.print(((*chargeControllerRegisterData[nodeId][28]*65536 + *chargeControllerRegisterData[nodeId][29])*0.001));
-	Serial.println(F("KWh"));
+    // Print the cumulative power hours:
+    Serial.print(F("Cumulative Power:\t\t"));
+    Serial.print(((*chargeControllerRegisterData[nodeId][28]*65536 + *chargeControllerRegisterData[nodeId][29])*0.001));
+    Serial.println(F("KWh"));
 
-	// Print the cumulative load amp hours:
-	Serial.print(F("Load Power:\t\t\t"));
-	Serial.print(((*chargeControllerRegisterData[nodeId][30]*65536 + *chargeControllerRegisterData[nodeId][31])*0.001));
-	Serial.println(F("KWh"));
+    // Print the cumulative load amp hours:
+    Serial.print(F("Load Power:\t\t\t"));
+    Serial.print(((*chargeControllerRegisterData[nodeId][30]*65536 + *chargeControllerRegisterData[nodeId][31])*0.001));
+    Serial.println(F("KWh"));
 
-	Serial.println(F("--------------- FAULT DATA ---------------"));
+    Serial.println(F("--------------- FAULT DATA ---------------"));
 
-	// Determine if there are any faults / what they mean.
-	String faults = "- None :)";
-	int faultID = *chargeControllerRegisterData[nodeId][34];
-	if(faultID != 0){
-		if(faultID > 16384 || faultID < 0){
-			faults = "- Invalid fault code!";
-		}
-		else{
-			faults = "";
-			int count = 0;
-			int faultCount = 0;
-			while(faultID != 0){
-				if(faultID >= pow(2, 15-count)){
-					// If there is more than one error, make a new line.
-					if(faultCount > 0){
-						faults += "\n";
-					}
-					faults += "- ";
-					faults += faultCodes[count-1];
-					faultID -= pow(2, 15-count);
-					faultCount++;
-				}
-				count++;
-			}
-		}
-	}
-	// Print the faults
-	Serial.println(F("Faults:"));
-	Serial.println(faults);
+    // Determine if there are any faults / what they mean.
+    String faults = "- None :)";
+    int faultID = *chargeControllerRegisterData[nodeId][34];
+    if(faultID != 0){
+        if(faultID > 16384 || faultID < 0){
+            faults = "- Invalid fault code!";
+        }
+        else{
+            faults = "";
+            int count = 0;
+            int faultCount = 0;
+            while(faultID != 0){
+                if(faultID >= pow(2, 15-count)){
+                    // If there is more than one error, make a new line.
+                    if(faultCount > 0){
+                        faults += "\n";
+                    }
+                    faults += "- ";
+                    faults += faultCodes[count-1];
+                    faultID -= pow(2, 15-count);
+                    faultCount++;
+                }
+                count++;
+            }
+        }
+    }
+    // Print the faults
+    Serial.println(F("Faults:"));
+    Serial.println(faults);
 
-	// Print the raw fault data
-	Serial.print(F("RAW Fault Data:\t\t\t"));
-	Serial.println(*chargeControllerRegisterData[nodeId][34]);
-	Serial.println(F("------------------------------------------\n"));
+    // Print the raw fault data
+    Serial.print(F("RAW Fault Data:\t\t\t"));
+    Serial.println(*chargeControllerRegisterData[nodeId][34]);
+    Serial.println(F("------------------------------------------\n"));
 }
 
 void loop(){

--- a/Arduino-Version/Multiple-Charge-Controllers/SOLAR_SEND_CC1/SOLAR_SEND_CC1.ino
+++ b/Arduino-Version/Multiple-Charge-Controllers/SOLAR_SEND_CC1/SOLAR_SEND_CC1.ino
@@ -2,7 +2,7 @@
     Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
     
     This is an example to retrieve data from multiple charge controllers.
-	This is intended to be run on an Arduino nano, it will communicate with one charge controller and send the data to the receiver.
+    This is intended to be run on an Arduino nano, it will communicate with one charge controller and send the data to the receiver.
     
     See images and schematic for wiring details.
 */
@@ -14,7 +14,7 @@
 #include <avr/wdt.h>        // Watchdog timer.
 
 /*
-	Pins to use for software serial for talking to the charge controller through the MAX3232.
+    Pins to use for software serial for talking to the charge controller through the MAX3232.
 */
 #define MAX3232_RX 2 // RX pin.
 #define MAX3232_TX 3 // TX pin.
@@ -30,9 +30,9 @@
     Modbus Constants
 */
 /*
-	All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
-	The library I use will not work with address 255 initially and must be modified, see the README for details.
-	You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
+    All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
+    The library I use will not work with address 255 initially and must be modified, see the README for details.
+    You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
 */
 #define MODBUS_SLAVE_ADDR 255
 #define MODBUS_READ_CODE 3
@@ -65,7 +65,6 @@ enum STATE {
 STATE state;
 
 unsigned long lastTime; // Last time isTime() was run and returned 1.
-
 uint16_t lastErrCnt; // Used to keep tract of modbus errors so we can compare to see how many new errors were generated.
 
 // Create the RF24 radio and network.

--- a/Arduino-Version/Multiple-Charge-Controllers/SOLAR_SEND_CC1/SOLAR_SEND_CC1.ino
+++ b/Arduino-Version/Multiple-Charge-Controllers/SOLAR_SEND_CC1/SOLAR_SEND_CC1.ino
@@ -1,5 +1,5 @@
 /*
-    Cole L - 20th November 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
+    Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
     
     This is an example to retrieve data from multiple charge controllers.
 	This is intended to be run on an Arduino nano, it will communicate with one charge controller and send the data to the receiver.
@@ -29,7 +29,12 @@
 /*
     Modbus Constants
 */
-#define MODBUS_SLAVE_ADDR 1
+/*
+	All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
+	The library I use will not work with address 255 initially and must be modified, see the README for details.
+	You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
+*/
+#define MODBUS_SLAVE_ADDR 255
 #define MODBUS_READ_CODE 3
 #define MODBUS_REQUEST1_START_ADDR 256
 #define MODBUS_REQUEST2_START_ADDR 280

--- a/Arduino-Version/Multiple-Charge-Controllers/SOLAR_SEND_CC2/SOLAR_SEND_CC2.ino
+++ b/Arduino-Version/Multiple-Charge-Controllers/SOLAR_SEND_CC2/SOLAR_SEND_CC2.ino
@@ -2,7 +2,7 @@
     Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
     
     This is an example to retrieve data from multiple charge controllers.
-	This is intended to be run on an Arduino nano, it will communicate with one charge controller and send the data to the receiver.
+    This is intended to be run on an Arduino nano, it will communicate with one charge controller and send the data to the receiver.
     
     See images and schematic for wiring details.
 */
@@ -14,7 +14,7 @@
 #include <avr/wdt.h>        // Watchdog timer.
 
 /*
-	Pins to use for software serial for talking to the charge controller through the MAX3232.
+    Pins to use for software serial for talking to the charge controller through the MAX3232.
 */
 #define MAX3232_RX 2 // RX pin.
 #define MAX3232_TX 3 // TX pin.
@@ -30,9 +30,9 @@
     Modbus Constants
 */
 /*
-	All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
-	The library I use will not work with address 255 initially and must be modified, see the README for details.
-	You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
+    All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
+    The library I use will not work with address 255 initially and must be modified, see the README for details.
+    You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
 */
 #define MODBUS_SLAVE_ADDR 255
 #define MODBUS_READ_CODE 3
@@ -65,7 +65,6 @@ enum STATE {
 STATE state;
 
 unsigned long lastTime; // Last time isTime() was run and returned 1.
-
 uint16_t lastErrCnt; // Used to keep tract of modbus errors so we can compare to see how many new errors were generated.
 
 // Create the RF24 radio and network.

--- a/Arduino-Version/Multiple-Charge-Controllers/SOLAR_SEND_CC2/SOLAR_SEND_CC2.ino
+++ b/Arduino-Version/Multiple-Charge-Controllers/SOLAR_SEND_CC2/SOLAR_SEND_CC2.ino
@@ -1,5 +1,5 @@
 /*
-    Cole L - 20th November 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
+    Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
     
     This is an example to retrieve data from multiple charge controllers.
 	This is intended to be run on an Arduino nano, it will communicate with one charge controller and send the data to the receiver.
@@ -29,7 +29,12 @@
 /*
     Modbus Constants
 */
-#define MODBUS_SLAVE_ADDR 1
+/*
+	All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
+	The library I use will not work with address 255 initially and must be modified, see the README for details.
+	You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
+*/
+#define MODBUS_SLAVE_ADDR 255
 #define MODBUS_READ_CODE 3
 #define MODBUS_REQUEST1_START_ADDR 256
 #define MODBUS_REQUEST2_START_ADDR 280

--- a/Arduino-Version/My-Current-Seup/SOLAR_RECEIVE/SOLAR_RECEIVE.ino
+++ b/Arduino-Version/My-Current-Seup/SOLAR_RECEIVE/SOLAR_RECEIVE.ino
@@ -1,17 +1,17 @@
 /*
-    Cole L - 20th November 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
-    
-    For my application there are four arduinos inside a deck box, three of them read data from a charge controller that is attached to it (CC1, CC2, CC3),
-    and the last one reads sensor data from a BME680 and a few ACS724 current sensors.
-    
-    This ESP8266 then processes the data from the transmitters and then publishes it to an MQTT server as well as displays it on an attached LCD.
+	Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
 
-    This code runs on an ESP8266 NODEMCU 0.9 module.
+	For my application there are four arduinos inside a deck box, three of them read data from a charge controller that is attached to it (CC1, CC2, CC3),
+	and the last one reads sensor data from a BME680 and a few ACS724 current sensors.
 
-    Attached components are:
-    - Generic 20x4 character I2C lcd display
-    - RF24 Module
-    - Capacitors on the 3.3V and 5V power rails to prevent voltage drops.
+	This ESP8266 then processes the data from the transmitters and then publishes it to an MQTT server as well as displays it on an attached LCD.
+
+	This code runs on an ESP8266 NODEMCU 0.9 module.
+
+	Attached components are:
+	- Generic 20x4 character I2C lcd display
+	- RF24 Module
+	- Capacitors on the 3.3V and 5V power rails to prevent voltage drops.
 */
 
 #include <RF24.h>              // Library version 1.3.12 works, 1.4.0 did not.
@@ -22,13 +22,13 @@
 // #include <math.h>              // Use this for pow().
 
 /*
-    WiFi Settings.
+	WiFi Settings.
 */
 #define WIFI_SSID "YOUR_WIFI_SSID"
 #define WIFI_PASS "YOUR_WIFI_PASSWORD"
 
 /*
-    MQTT related settings. You many need to change these depending on your implementation.
+	MQTT related settings. You many need to change these depending on your implementation.
 */
 #define MQTT_PORT 1883                   // Port to use for MQTT.
 #define MQTT_SERVER_ADDR "192.168.2.100" // Address of the MQTT server.
@@ -37,29 +37,29 @@
 #define NUM_MISC_MQTT_TOPICS 7           // Number of misc data related MQTT topics.
 
 /*
-    Offset of the ACS724 current sensors used for the misc data.
-    In theory these should be 2.5 but my sensors kinda suck.
-    Found experimentally, your numbers will differ.
+	Offset of the ACS724 current sensors used for the misc data.
+	In theory these should be 2.5 but my sensors kinda suck.
+	Found experimentally, your numbers will differ.
 */
-#define FRONT_AMPS_SENSOR_A_OFFSET 2.23 
+#define FRONT_AMPS_SENSOR_A_OFFSET 2.23
 #define FRONT_AMPS_SENSOR_B_OFFSET 2.36
 #define BACK_AMPS_SENSOR_OFFSET 2.40
 
-/* 
-    Multipliers for the ADC and Current sensors.
+/*
+	Multipliers for the ADC and Current sensors.
 */
 #define ADS1115_VPB 0.0001875 // Volts per bit of the ADS1115 ADC (6.144V/32768).
 #define ACS724_VPA 0.066      // Volts per amp of the ACS724 current sensor.
 
 /*
-    I had issues with the transmitter's Serial buffers running out of room when receiving more than 29 registers at once 
-    from the charge controller. Solved this by just sending two separate requests to get all the data I wanted.
+	I had issues with the transmitter's Serial buffers running out of room when receiving more than 29 registers at once
+	from the charge controller. Solved this by just sending two separate requests to get all the data I wanted.
 */
 #define NUM_REGISTERS_REQUEST1 24
 #define NUM_REGISTERS_REQUEST2 11
 
 /*
-    Other constant and settings.
+	Other constant and settings.
 */
 #define NUM_MISC_DATA_NODES 1      // Number of nodes which will be reporting misc data. Addresses of misc nodes must start counting up from 1. 
 #define NUM_CHARGE_CONTROLLERS 3   // Number of nodes that will report charge controller data. Addresses of charge controller nodes must start counting up from at NUM_MISC_DATA_NODES+1.
@@ -81,26 +81,26 @@
 #define WATTS_STRING_MAX_CHARS 6   // Maximum number of characters for the watts string for the lcd. Includes the W unit and null.
 
 /*
-    Structure for the charge controller data from the charge controller nodes.
+	Structure for the charge controller data from the charge controller nodes.
 */
 typedef struct package{
     uint16_t modbusErrDiff;                    // Number of new modbus errors since last transmission.
-    uint16_t request1[NUM_REGISTERS_REQUEST1]; // First group of registers from the charge controller
-    uint16_t request2[NUM_REGISTERS_REQUEST2]; // Second group of registers from the charge controller
+	uint16_t request1[NUM_REGISTERS_REQUEST1]; // First group of registers from the charge controller
+	uint16_t request2[NUM_REGISTERS_REQUEST2]; // Second group of registers from the charge controller
 }Package;
 Package chargeControllerNodeData[NUM_CHARGE_CONTROLLERS];
 
 /*
-    This is the structure which is transmitted from the misc data node to the receiver.
-    I have some other sensors I want to receive data from so I decided to separate them from the charge controller transmissions.
-    Front panel amps are split into two parts because the ACS724 only goes up to 30A and I needed 60A, so I placed two ACS724 sensors in parallel.
-    These are the raw sensor values and they need to be translated into their actual values later.
+	This is the structure which is transmitted from the misc data node to the receiver.
+	I have some other sensors I want to receive data from so I decided to separate them from the charge controller transmissions.
+	Front panel amps are split into two parts because the ACS724 only goes up to 30A and I needed 60A, so I placed two ACS724 sensors in parallel.
+	These are the raw sensor values and they need to be translated into their actual values later.
 */
 typedef struct package2{
-    float panelAmpsBack;   // Measured Back panel amps (ACS712 current sensor)
-    float panelAmpsFrontA; // Measured Front panel amps sensor 1/2 (ACS724 curent sensor)
-    float panelAmpsFrontB; // Measured Front panel amps sensor 1/2 (ACS724 curent sensor)
-    // float batteryVolts;     // Measured battery voltage (ADS1115 and a voltage divider. R1=56K, R2=10K) // Input 0 of my ADC is broken, enable if you need this.
+	float panelAmpsBack;   // Measured Back panel amps (ACS712 current sensor)
+	float panelAmpsFrontA; // Measured Front panel amps sensor 1/2 (ACS724 curent sensor)
+	float panelAmpsFrontB; // Measured Front panel amps sensor 1/2 (ACS724 curent sensor)
+	// float batteryVolts;     // Measured battery voltage (ADS1115 and a voltage divider. R1=56K, R2=10K) // Input 0 of my ADC is broken, enable if you need this.
     int32_t bmePres;       // Atmospheric pressure measured by BME680
     int32_t bmeTemp;       // Air temperature measured by BME680
     int32_t bmeHum;        // Air humidity measured by BME680
@@ -109,14 +109,14 @@ typedef struct package2{
 Package2 miscNodeData;
 
 /*
-    2D Array of pointers to make it easier to retrieve charge controller data.
+	2D Array of pointers to make it easier to retrieve charge controller data.
 */
 uint16_t* chargeControllerRegisterData[NUM_CHARGE_CONTROLLERS][NUM_REGISTERS_REQUEST1 + NUM_REGISTERS_REQUEST2];
 
 /*
-    Array of all MQTT topic names related to the charge controllers.
-    "CCX" will be appended to the start, X indicating the node/charge controller number.
-    You can change these as you see fit, just make sure whatever you are using to receive them also uses the same topic names.
+	Array of all MQTT topic names related to the charge controllers.
+	"CCX" will be appended to the start, X indicating the node/charge controller number.
+	You can change these as you see fit, just make sure whatever you are using to receive them also uses the same topic names.
 */
 const char* chargeControllerTopics[NUM_CC_MQTT_TOPICS]={
     "modbusErrDiff",        //0  Number of new modbus errors since last refresh.
@@ -144,9 +144,9 @@ const char* chargeControllerTopics[NUM_CC_MQTT_TOPICS]={
 };
 
 /*
-    Array of topics not related to the charge controller data.
-    These are sent by the misc data node.
-    These are treated by pub() as if their index is part of chargeControllerTopics.
+	Array of topics not related to the charge controller data.
+	These are sent by the misc data node.
+	These are treated by pub() as if their index is part of chargeControllerTopics.
 */
 const char* miscDataTopics[NUM_MISC_MQTT_TOPICS]={
     "dcAmpsB", //0 Direct measured Amps Back
@@ -159,8 +159,8 @@ const char* miscDataTopics[NUM_MISC_MQTT_TOPICS]={
 };
 
 /*
-    Array of charging mode strings.
-    These are the states the charge controller can be in when charging the battery.
+	Array of charging mode strings.
+	These are the states the charge controller can be in when charging the battery.
 */
 const char* chargeModes[7]={
     "OFF",             //0
@@ -173,7 +173,7 @@ const char* chargeModes[7]={
 };
 
 /*
-    Custom symbols for the LCD.
+	Custom symbols for the LCD.
 */
 byte omegaSymbol[] = { // Omega Symbol (Ohms)
     0x00,0x0E,0x11,0x11,0x11,0x0A,0x1B,0x00
@@ -183,12 +183,12 @@ byte degC[] = { // Degrees Celsius Symbol
 };
 
 /*
-    Hold converted bme readings.
+	Hold converted bme readings.
 */
 float bmePres, bmeTemp, bmeHum, bmeGas;
 
 /*
-    Used to avoid trying to publish data to mqtt if it failed to connect on startup.
+	Used to avoid trying to publish data to mqtt if it failed to connect on startup.
 */
 short mqttConnected;
 
@@ -205,194 +205,194 @@ PubSubClient client(MQTT_SERVER_ADDR, MQTT_PORT, wifiClient);
 
 void setup(){
     while (!Serial);
-    Serial.begin(115200);
-    
-    lcd.begin(); // Startup LCD
-    
-    // Load custom characters into display ram.
-    lcd.createChar(0, omegaSymbol);
-    lcd.createChar(1, degC);
+	Serial.begin(115200);
 
-    lcd.backlight(); // Turn on the LCD backlight
-    lcd.setCursor(0, 0);
-    lcd.print(F("Connecting"));
+	lcd.begin(); // Startup LCD
 
-    // Startup the RF24
+	// Load custom characters into display ram.
+	lcd.createChar(0, omegaSymbol);
+	lcd.createChar(1, degC);
+
+	lcd.backlight(); // Turn on the LCD backlight
+	lcd.setCursor(0, 0);
+	lcd.print(F("Connecting"));
+
+	// Startup the RF24
     while(!radio.begin()){
-        Serial.print(F("\nUnable to start RF24.\n"));
-        delay(SETUP_FAIL_DELAY);
-    }
-    network.begin(RF24_NETWORK_CHANNEL, RECEIVE_NODE_ADDR);
-    Serial.println(F("RF24 Initialized"));
+		Serial.print(F("\nUnable to start RF24.\n"));
+		delay(SETUP_FAIL_DELAY);
+	}
+	network.begin(RF24_NETWORK_CHANNEL, RECEIVE_NODE_ADDR);
+	Serial.println(F("RF24 Initialized"));
 
-    WiFi.begin(WIFI_SSID, WIFI_PASS); // Begin WiFi connection
-    // Wait for connection
-    int trys = 0;
+	WiFi.begin(WIFI_SSID, WIFI_PASS); // Begin WiFi connection
+	// Wait for connection
+	int trys = 0;
     while (WiFi.status() != WL_CONNECTED) {
         if(trys > WIFI_MAX_WAITS){
-            lcd.clear();
-            lcd.setCursor(0,0);
-            lcd.print(F("WiFi Disconnected :("));
-            lcd.setCursor(0, 1);
-            lcd.print(F("Skipping MQTT..."));
-            mqttConnected = 0;
-            break;
-        }
-        delay(WIFI_SINGLE_WAIT_DELAY);
-        Serial.print(F("."));
-        lcd.print(F("."));
-        trys++;
-    }
+			lcd.clear();
+            lcd.setCursor(0, 0);
+			lcd.print(F("WiFi Disconnected :("));
+			lcd.setCursor(0, 1);
+			lcd.print(F("Skipping MQTT..."));
+			mqttConnected = 0;
+			break;
+		}
+		delay(WIFI_SINGLE_WAIT_DELAY);
+		Serial.print(F("."));
+		lcd.print(F("."));
+		trys++;
+	}
     if(WiFi.status() == WL_CONNECTED) {
-        lcd.clear();
-        lcd.setCursor(0, 0);
-        lcd.print(F("Connected :)"));
-        lcd.setCursor(0, 1);
-        lcd.print(F("SSID: "));
-        lcd.print(WIFI_SSID);
-        lcd.setCursor(0, 2);
-        lcd.print(F("IP: "));
-        lcd.print(WiFi.localIP());
-        lcd.setCursor(0, 3);
+		lcd.clear();
+		lcd.setCursor(0, 0);
+		lcd.print(F("Connected :)"));
+		lcd.setCursor(0, 1);
+		lcd.print(F("SSID: "));
+		lcd.print(WIFI_SSID);
+		lcd.setCursor(0, 2);
+		lcd.print(F("IP: "));
+		lcd.print(WiFi.localIP());
+		lcd.setCursor(0, 3);
 
-        Serial.print(F("\nConnected to "));
-        Serial.println(WIFI_SSID);
-        Serial.print(F("IP address: "));
-        Serial.println(WiFi.localIP());
+		Serial.print(F("\nConnected to "));
+		Serial.println(WIFI_SSID);
+		Serial.print(F("IP address: "));
+		Serial.println(WiFi.localIP());
 
-        // Connect to MQTT Broker
+		// Connect to MQTT Broker
         if (client.connect(MQTT_CLIENT_ID)) {
-            lcd.print(F("MQTT Connected :)"));
-            Serial.println(F("MQTT Connected"));
-            mqttConnected = 1;
-        }
+			lcd.print(F("MQTT Connected :)"));
+			Serial.println(F("MQTT Connected"));
+			mqttConnected = 1;
+		}
         else {
-            lcd.print(F("MQTT Failed :("));
-            Serial.println(F("MQTT Connection failed..."));
-            mqttConnected = 0;
-        }
-    }
+			lcd.print(F("MQTT Failed :("));
+			Serial.println(F("MQTT Connection failed..."));
+			mqttConnected = 0;
+		}
+	}
 
-    // Make a 2D array of pointers to make it easier to access the charge controller data.
-    // Initialize pointers array for request1 registers.
+	// Make a 2D array of pointers to make it easier to access the charge controller data.
+	// Initialize pointers array for request1 registers.
     for(int i = 0; i<NUM_REGISTERS_REQUEST1; i++){
         for(int j = 0; j<NUM_CHARGE_CONTROLLERS; j++){
-            chargeControllerRegisterData[j][i] = &chargeControllerNodeData[j].request1[i];
-        }
-    }
-    // Initialize pointers array for request2 registers.
+			chargeControllerRegisterData[j][i] = &chargeControllerNodeData[j].request1[i];
+		}
+	}
+	// Initialize pointers array for request2 registers.
     for(int i = 0; i<NUM_REGISTERS_REQUEST2; i++){
         for(int j = 0; j<NUM_CHARGE_CONTROLLERS; j++){
-            chargeControllerRegisterData[j][i + NUM_REGISTERS_REQUEST1] = &chargeControllerNodeData[j].request2[i];
-        }
-    }
+			chargeControllerRegisterData[j][i + NUM_REGISTERS_REQUEST1] = &chargeControllerNodeData[j].request2[i];
+		}
+	}
 
-    bmePres = bmeTemp = bmeHum = bmeGas = 0;
+	bmePres = bmeTemp = bmeHum = bmeGas = 0;
 
-    delay(1500); // Give enough time to read the details from the display.
+	delay(1500); // Give enough time to read the details from the display.
 }
 
 /*
-    Helper function to handle the sign bit for negative temperatures.
+	Helper function to handle the sign bit for negative temperatures.
 */
 int getRealTemp(int temp){
     return temp/128 ? -(temp%128) : temp;
 }
 
 /*
-    Generate the watts string to be printed on the LCD
-    When nodeId is negative then calculate the total across all charge controllers.
+	Generate the watts string to be printed on the LCD
+	When nodeId is negative then calculate the total across all charge controllers.
 */
 void getWattsForDisplay(char* wattsString, int nodeId){
-    int watts = 0;
-    
-    // Calculate the total across all charge controllers.
+	int watts = 0;
+
+	// Calculate the total across all charge controllers.
     if(nodeId < 0){
         for(int i = 0; i<NUM_CHARGE_CONTROLLERS; i++){
             if(!chargeControllerNodeData[i].modbusErrDiff){
-                watts += (int)(*chargeControllerRegisterData[i][9]);
-            }
-        }
-    }
-    // Is the charge controller offline?
+				watts += (int)(*chargeControllerRegisterData[i][9]);
+			}
+		}
+	}
+	// Is the charge controller offline?
     else if(chargeControllerNodeData[nodeId].modbusErrDiff){
-        snprintf(wattsString, WATTS_STRING_MAX_CHARS, "----W");
-        return;
-    }
+		snprintf(wattsString, WATTS_STRING_MAX_CHARS, "----W");
+		return;
+	}
     else{
-        watts = (int)(*chargeControllerRegisterData[nodeId][9]);
-    }
+		watts = (int)(*chargeControllerRegisterData[nodeId][9]);
+	}
 
-    snprintf(wattsString, WATTS_STRING_MAX_CHARS, "%dW", watts);
-    
-    // Generate the correct spacing after the watts number.
+	snprintf(wattsString, WATTS_STRING_MAX_CHARS, "%dW", watts);
+
+	// Generate the correct spacing after the watts number.
     if(watts < 10){
-        char space[4] = "   ";
-        strncat(wattsString, space, 3);
-    }
+		char space[4] = "   ";
+		strncat(wattsString, space, 3);
+	}
     else{
-        char space[2] = " ";
+		char space[2] = " ";
         while(watts/1000 == 0){
-            watts *= 10;
-            strncat(wattsString, space, 1);
-        }
-    }
+			watts *= 10;
+			strncat(wattsString, space, 1);
+		}
+	}
 }
 
 /*
-    Print data to the attached LCD.
+	Print data to the attached LCD.
 */
 void printLCD(){
-    // Prepare display contents before we clear the display.
-    // By doing this we decrease how long the display blanks for.
+	// Prepare display contents before we clear the display.
+	// By doing this we decrease how long the display blanks for.
 
     char* wattsString = (char*)malloc(WATTS_STRING_MAX_CHARS);
 
-    // T: XXXXW Bat: XX.XV
-    char row1[ROW_1_MAX_CHARS];
-    getWattsForDisplay(wattsString, -1); // Get total watts.
+	// T: XXXXW Bat: XX.XV
+	char row1[ROW_1_MAX_CHARS];
+	getWattsForDisplay(wattsString, -1); // Get total watts.
     snprintf(row1, sizeof(row1), "T:%s Bat: %.1fV", wattsString, *chargeControllerRegisterData[2][1]*0.1);
 
-    // E:XXXXW Tmp: XX.XX°C (°C is written later)
-    char row2[ROW_2_MAX_CHARS];
-    getWattsForDisplay(wattsString, 0); // Get CC1 watts.
-    snprintf(row2, sizeof(row2), "F:%s Tmp: %.2f", wattsString, bmeTemp);
+	// E:XXXXW Tmp: XX.XX°C (°C is written later)
+	char row2[ROW_2_MAX_CHARS];
+	getWattsForDisplay(wattsString, 0); // Get CC1 watts.
+	snprintf(row2, sizeof(row2), "F:%s Tmp: %.2f", wattsString, bmeTemp);
 
-    // S:XXXXW Hum: XX%
-    char row3[ROW_3_MAX_CHARS];
-    getWattsForDisplay(wattsString, 1); // Get CC2 watts.
-    snprintf(row3, sizeof(row3), "S:%s Hum: %d%%", wattsString, (int)bmeHum);
+	// S:XXXXW Hum: XX%
+	char row3[ROW_3_MAX_CHARS];
+	getWattsForDisplay(wattsString, 1); // Get CC2 watts.
+	snprintf(row3, sizeof(row3), "S:%s Hum: %d%%", wattsString, (int)bmeHum);
 
-    // W:XXXXW Gas: XXXXX
+	// W:XXXXW Gas: XXXXX
     char row4[ROW_4_PART1_MAX_CHARS+ROW_4_PART2_MAX_CHARS-1]; // -1 because part 1 includes null that is overwritten.
     getWattsForDisplay(wattsString, 2); // Get CC3 watts.
-    snprintf(row4, ROW_4_PART1_MAX_CHARS, "B:%s Gas: ", wattsString);
+	snprintf(row4, ROW_4_PART1_MAX_CHARS, "B:%s Gas: ", wattsString);
     if(bmeGas >= 10000){
         snprintf(&row4[13], ROW_4_PART2_MAX_CHARS, "%dM", (int)bmeGas/1000);
-    }
+	}
     else{
-        snprintf(&row4[13], ROW_4_PART2_MAX_CHARS, "%dk", (int)bmeGas);
-    }
+		snprintf(&row4[13], ROW_4_PART2_MAX_CHARS, "%dk", (int)bmeGas);
+	}
 
-    // Clear the display and start writing to it.
-    lcd.clear();
+	// Clear the display and start writing to it.
+	lcd.clear();
 
-    lcd.print(row1);
+	lcd.print(row1);
 
-    lcd.setCursor(0, 1);
-    lcd.print(row2);
-    lcd.setCursor((int)(strlen(&row2[0])), 1);
-    lcd.write(1); // Write the degC symbol (degrees Celsius)
-    
-    lcd.setCursor(0, 2);
-    lcd.print(row3);
+	lcd.setCursor(0, 1);
+	lcd.print(row2);
+	lcd.setCursor((int)(strlen(&row2[0])), 1);
+	lcd.write(1); // Write the degC symbol (degrees Celsius)
 
-    lcd.setCursor(0, 3);
-    lcd.print(row4);
-    lcd.setCursor((int)(strlen(&row4[0])), 3);
-    lcd.write(0); // Write the omega symbol (Ohm)
+	lcd.setCursor(0, 2);
+	lcd.print(row3);
 
-    free(wattsString);
+	lcd.setCursor(0, 3);
+	lcd.print(row4);
+	lcd.setCursor((int)(strlen(&row4[0])), 3);
+	lcd.write(0); // Write the omega symbol (Ohm)
+
+	free(wattsString);
 }
 
 // Function to correct the voltage measurement. Found experimentally, will differ by setup.
@@ -402,230 +402,233 @@ void printLCD(){
 // }
 
 /*
-    Publish MQTT data that is not misc data.
-    topicIndex is the index of the topic name, val is the actual data value, nodeId indicates which node the data came from.
+	Publish MQTT data that is not misc data.
+	topicIndex is the index of the topic name, val is the actual data value, nodeId indicates which node the data came from.
 */
 void pub(int topicIndex, float val, int nodeId=0){
-    // Build the topic name.
+	// Build the topic name.
     char* tempTopic;
-    // If the topicIndex is outside the range of the charge controller topics, switch to misc data topics.
+	// If the topicIndex is outside the range of the charge controller topics, switch to misc data topics.
     if(topicIndex >= NUM_CC_MQTT_TOPICS){
         int topicSize = strlen(miscDataTopics[topicIndex - NUM_CC_MQTT_TOPICS])+1; // +1 for null terminator.
         tempTopic = (char*)malloc(topicSize);
-        snprintf(tempTopic, topicSize, "%s", miscDataTopics[topicIndex - NUM_CC_MQTT_TOPICS]);
-    }
+		snprintf(tempTopic, topicSize, "%s", miscDataTopics[topicIndex - NUM_CC_MQTT_TOPICS]);
+	}
     else{
-        int topicSize = strlen(chargeControllerTopics[topicIndex]) + strlen(CC_TOPIC_PREFIX) + 2; // +1 for null terminator and +1 for the charge controller number after the CC prefix. >9 will need adjustment.
+		int topicSize = strlen(chargeControllerTopics[topicIndex]) + strlen(CC_TOPIC_PREFIX) + 2; // +1 for null terminator and +1 for the charge controller number after the CC prefix. >9 will need adjustment.
         tempTopic = (char*)malloc(topicSize);
-        snprintf(tempTopic, topicSize, "%s%d%s", CC_TOPIC_PREFIX, nodeId + 1, chargeControllerTopics[topicIndex]);
-    }
+		snprintf(tempTopic, topicSize, "%s%d%s", CC_TOPIC_PREFIX, nodeId + 1, chargeControllerTopics[topicIndex]);
+	}
 
-    // Is this the charging mode topic?
+	// Is this the charging mode topic?
     if(topicIndex == CHARGE_MODE_TOPIC_INDEX){
-        // See if load is turned on, if it is then we need to apply an offset since they share a register.
-        int loadOffset = *chargeControllerRegisterData[nodeId][32] > 6 ? 32768 : 0;
+		// See if load is turned on, if it is then we need to apply an offset since they share a register.
+		int loadOffset = *chargeControllerRegisterData[nodeId][32] > 6 ? 32768 : 0;
 
         if(!client.publish(tempTopic, chargeModes[*chargeControllerRegisterData[nodeId][32] - loadOffset])){
-            // If error then try reconnecting and publishing again.
+			// If error then try reconnecting and publishing again.
             if(client.connect(MQTT_CLIENT_ID)){
-                client.publish(tempTopic, chargeModes[*chargeControllerRegisterData[nodeId][32] - loadOffset]);
-            }
-        }
-    }
+				client.publish(tempTopic, chargeModes[*chargeControllerRegisterData[nodeId][32] - loadOffset]);
+			}
+		}
+	}
     else{
-        char tempVal[16];
-        
-        // Is this the modbus error topic?
+		char tempVal[16];
+
+		// Is this the modbus error topic?
         if(topicIndex == MODBUS_ERR_TOPIC_INDEX){
-            snprintf(tempVal, sizeof(tempVal), "%d", chargeControllerNodeData[nodeId].modbusErrDiff);
-        }
+			snprintf(tempVal, sizeof(tempVal), "%d", chargeControllerNodeData[nodeId].modbusErrDiff);
+		}
         else{
             snprintf(tempVal, sizeof(tempVal),"%f", val);
-        }
+		}
 
         if(!client.publish(tempTopic, tempVal)){
-            // If error then try reconnecting and publishing again.
-            Serial.println(F("Data not sent\n"));
+			// If error then try reconnecting and publishing again.
+			Serial.println(F("Data not sent\n"));
             if(client.connect(MQTT_CLIENT_ID)){
-                client.publish(tempTopic, tempVal);
-            }
-        }
-    }
-    free(tempTopic);
+				client.publish(tempTopic, tempVal);
+			}
+		}
+	}
+	free(tempTopic);
 }
 
 // Coordinate publishing the misc data which is not from the charge controllers.
 void publishMiscData(){
-    pub(0 + NUM_CC_MQTT_TOPICS, miscNodeData.panelAmpsBack);
-    pub(1 + NUM_CC_MQTT_TOPICS, miscNodeData.panelAmpsFrontA + miscNodeData.panelAmpsFrontB);
-    // pub(2 + NUM_CC_MQTT_TOPICS, miscNodeData.dcVolts); // Input 0 of my ADC is broken, enable if you need this.
-    pub(3 + NUM_CC_MQTT_TOPICS, bmeTemp);
-    pub(4 + NUM_CC_MQTT_TOPICS, bmeHum);
-    pub(5 + NUM_CC_MQTT_TOPICS, bmePres);
-    pub(6 + NUM_CC_MQTT_TOPICS, bmeGas);
+	if (!mqttConnected)
+		return; // Handle case where mqtt connection failed at initial startup, no point int trying to connect.
+
+	pub(0 + NUM_CC_MQTT_TOPICS, miscNodeData.panelAmpsBack);
+	pub(1 + NUM_CC_MQTT_TOPICS, miscNodeData.panelAmpsFrontA + miscNodeData.panelAmpsFrontB);
+	// pub(2 + NUM_CC_MQTT_TOPICS, miscNodeData.dcVolts); // Input 0 of my ADC is broken, enable if you need this.
+	pub(3 + NUM_CC_MQTT_TOPICS, bmeTemp);
+	pub(4 + NUM_CC_MQTT_TOPICS, bmeHum);
+	pub(5 + NUM_CC_MQTT_TOPICS, bmePres);
+	pub(6 + NUM_CC_MQTT_TOPICS, bmeGas);
 }
 
 /*
-    Coordinate publishing all charge controller data. nodeId is the address of the charge controller node - (NUM_MISC_DATA_NODES+1).
-    Register addresses were figured out from the modbus document, have a look at it if you are confused about them.
+	Coordinate publishing all charge controller data. nodeId is the address of the charge controller node - (NUM_MISC_DATA_NODES+1).
+	Register addresses were figured out from the modbus document, have a look at it if you are confused about them.
 */
 void publishCC(int nodeId){
     if(!mqttConnected) return; // Handle case where mqtt connection failed at initial startup, no point int trying to connect.
-    
-    // Publish modbus error
-    pub(0, 0, nodeId);
-    
-    // Publish the charging mode of the charge controller.
-    pub(1, 0, nodeId);
-    
-    // Publish battery state of charge.
-    pub(2, *chargeControllerRegisterData[nodeId][0], nodeId);
-    
-    // Publish battery volts.
+
+	// Publish modbus error
+	pub(0, 0, nodeId);
+
+	// Publish the charging mode of the charge controller.
+	pub(1, 0, nodeId);
+
+	// Publish battery state of charge.
+	pub(2, *chargeControllerRegisterData[nodeId][0], nodeId);
+
+	// Publish battery volts.
     pub(3, (*chargeControllerRegisterData[nodeId][1]*0.1), nodeId);
 
-    // Publish battery charging current.
+	// Publish battery charging current.
     pub(4, (*chargeControllerRegisterData[nodeId][2]*0.01), nodeId);
 
-    // Publish controller temperature.
-    pub(5, getRealTemp(*chargeControllerRegisterData[nodeId][3] >> 8), nodeId); // Controller and battery temps share a single register.
-    
-    // Publish battery temperature.
-    pub(6, getRealTemp(*chargeControllerRegisterData[nodeId][3] & 0xFF), nodeId);
+	// Publish controller temperature.
+	pub(5, getRealTemp(*chargeControllerRegisterData[nodeId][3] >> 8), nodeId); // Controller and battery temps share a single register.
 
-    // // Publish load voltage.
-    // pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][4]*0.1), nodeId);
-    // // Publish load current.
-    // pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][5]*0.01), nodeId);
-    // // Publish load wattage.
-    // pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][6]), nodeId);
+	// Publish battery temperature.
+	pub(6, getRealTemp(*chargeControllerRegisterData[nodeId][3] & 0xFF), nodeId);
 
-    // Publish battery volts.
+	// // Publish load voltage.
+	// pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][4]*0.1), nodeId);
+	// // Publish load current.
+	// pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][5]*0.01), nodeId);
+	// // Publish load wattage.
+	// pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][6]), nodeId);
+
+	// Publish battery volts.
     pub(7, (*chargeControllerRegisterData[nodeId][7]*0.1), nodeId);
 
-    // Publish panel current.
+	// Publish panel current.
     pub(8, (*chargeControllerRegisterData[nodeId][8]*0.01), nodeId);
 
-    // Publish panel watts.
-    pub(9, *chargeControllerRegisterData[nodeId][9], nodeId);
+	// Publish panel watts.
+	pub(9, *chargeControllerRegisterData[nodeId][9], nodeId);
 
-    // // Publish load status (on / off).
-    // pub(TOPIC_ID_HERE, *chargeControllerRegisterData[nodeId][10], nodeId);
+	// // Publish load status (on / off).
+	// pub(TOPIC_ID_HERE, *chargeControllerRegisterData[nodeId][10], nodeId);
 
-    // Publish battery daily min volts.
+	// Publish battery daily min volts.
     pub(10, (*chargeControllerRegisterData[nodeId][11]*0.1), nodeId);
 
-    // Publish battery daily max volts.
+	// Publish battery daily max volts.
     pub(11, (*chargeControllerRegisterData[nodeId][12]*0.1), nodeId);
 
-    // Publish battery daily max charging current.
+	// Publish battery daily max charging current.
     pub(12, (*chargeControllerRegisterData[nodeId][13]*0.01), nodeId);
 
-    // // Publish daily max load current.
-    // pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][14]*0.01), nodeId);
+	// // Publish daily max load current.
+	// pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][14]*0.01), nodeId);
 
-    // Publish daily max panel charging power.
-    pub(13, *chargeControllerRegisterData[nodeId][15], nodeId);
+	// Publish daily max panel charging power.
+	pub(13, *chargeControllerRegisterData[nodeId][15], nodeId);
 
-    // // Publish daily max load power.
-    // pub(TOPIC_ID_HERE, *chargeControllerRegisterData[nodeId][16], nodeId);
+	// // Publish daily max load power.
+	// pub(TOPIC_ID_HERE, *chargeControllerRegisterData[nodeId][16], nodeId);
 
-    // Publish daily charging amp hours.
-    pub(14, *chargeControllerRegisterData[nodeId][17], nodeId);
+	// Publish daily charging amp hours.
+	pub(14, *chargeControllerRegisterData[nodeId][17], nodeId);
 
-    // // Publish daily load amp hours.
-    // pub(TOPIC_ID_HERE, *chargeControllerRegisterData[nodeId][18], inodeIdd);
+	// // Publish daily load amp hours.
+	// pub(TOPIC_ID_HERE, *chargeControllerRegisterData[nodeId][18], inodeIdd);
 
-    // Publish daily power generated.
+	// Publish daily power generated.
     pub(15, (*chargeControllerRegisterData[nodeId][19]*0.001), nodeId);
 
-    // // Publish daily load power used.
-    // pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][20]*0.001), nodeId);
+	// // Publish daily load power used.
+	// pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][20]*0.001), nodeId);
 
-    // Publish number of days operational
-    pub(16, *chargeControllerRegisterData[nodeId][21], nodeId);
+	// Publish number of days operational
+	pub(16, *chargeControllerRegisterData[nodeId][21], nodeId);
 
-    // Publish number of battery over-discharges
-    pub(17, *chargeControllerRegisterData[nodeId][22], nodeId);
+	// Publish number of battery over-discharges
+	pub(17, *chargeControllerRegisterData[nodeId][22], nodeId);
 
-    // Publish number of battery full-charges
-    pub(18, *chargeControllerRegisterData[nodeId][23], nodeId);
+	// Publish number of battery full-charges
+	pub(18, *chargeControllerRegisterData[nodeId][23], nodeId);
 
-    // Publish total battery charging amp-hours.
+	// Publish total battery charging amp-hours.
     pub(19, ((*chargeControllerRegisterData[nodeId][24]*65536 + *chargeControllerRegisterData[nodeId][25])*0.001), nodeId);
 
-    // // Publish total load consumption amp-hours.
-    // pub(TOPIC_ID_HERE, ((*chargeControllerRegisterData[nodeId][26]*65536 + *chargeControllerRegisterData[nodeId][27])*0.001), nodeId);
+	// // Publish total load consumption amp-hours.
+	// pub(TOPIC_ID_HERE, ((*chargeControllerRegisterData[nodeId][26]*65536 + *chargeControllerRegisterData[nodeId][27])*0.001), nodeId);
 
-    // Publish total power generation.
+	// Publish total power generation.
     pub(20, ((*chargeControllerRegisterData[nodeId][28]*65536 + *chargeControllerRegisterData[nodeId][29])*0.001), nodeId);
 
-    // // Publish total load power consumption.
-    // pub(TOPIC_ID_HERE, ((*chargeControllerRegisterData[nodeId][30]*65536 + *chargeControllerRegisterData[nodeId][31])*0.001), nodeId);
+	// // Publish total load power consumption.
+	// pub(TOPIC_ID_HERE, ((*chargeControllerRegisterData[nodeId][30]*65536 + *chargeControllerRegisterData[nodeId][31])*0.001), nodeId);
 
-    // Register 32 is charging state which is handled in the first pub() call, 33 is reserved. 
+	// Register 32 is charging state which is handled in the first pub() call, 33 is reserved.
 
-    // Publish fault data.
-    pub(21, *chargeControllerRegisterData[nodeId][34], nodeId);
+	// Publish fault data.
+	pub(21, *chargeControllerRegisterData[nodeId][34], nodeId);
 }
 
 void loop(){
-    network.update();
+	network.update();
     if(network.available()){
         while(network.available()){
-            RF24NetworkHeader header;                                             
-            network.peek(header);
+			RF24NetworkHeader header;
+			network.peek(header);
 
-            // See which node this transmission is from.
-            // If from a node reporting misc data, treat differently.
+			// See which node this transmission is from.
+			// If from a node reporting misc data, treat differently.
             if(header.from_node <= NUM_MISC_DATA_NODES && header.from_node > 0){
-                // If multiple misc data nodes you may mant to treat them differently here.
-                // For my application I only have 1 misc node so I won't do that.
-                
-                network.read(header, &miscNodeData, sizeof(miscNodeData));
-                delay(10);
-                
-                // Convert the raw sensor data values from the transmitter into their actual values.
-                // miscNodeData.dcVolts = voltApprox(miscNodeData.dcVolts*ADS1115_VPB); // Input 0 of my ADC is broken, enable if you need this.
-                miscNodeData.panelAmpsFrontA = (FRONT_AMPS_SENSOR_A_OFFSET - miscNodeData.panelAmpsFrontA * ADS1115_VPB) / ACS724_VPA;
-                miscNodeData.panelAmpsFrontB = (FRONT_AMPS_SENSOR_B_OFFSET - miscNodeData.panelAmpsFrontB * ADS1115_VPB) / ACS724_VPA;
-                miscNodeData.panelAmpsBack = (BACK_AMPS_SENSOR_OFFSET - miscNodeData.panelAmpsBack * ADS1115_VPB) / ACS724_VPA;
+				// If multiple misc data nodes you may mant to treat them differently here.
+				// For my application I only have 1 misc node so I won't do that.
+
+				network.read(header, &miscNodeData, sizeof(miscNodeData));
+				delay(10);
+
+				// Convert the raw sensor data values from the transmitter into their actual values.
+				// miscNodeData.dcVolts = voltApprox(miscNodeData.dcVolts*ADS1115_VPB); // Input 0 of my ADC is broken, enable if you need this.
+				miscNodeData.panelAmpsFrontA = (FRONT_AMPS_SENSOR_A_OFFSET - miscNodeData.panelAmpsFrontA * ADS1115_VPB) / ACS724_VPA;
+				miscNodeData.panelAmpsFrontB = (FRONT_AMPS_SENSOR_B_OFFSET - miscNodeData.panelAmpsFrontB * ADS1115_VPB) / ACS724_VPA;
+				miscNodeData.panelAmpsBack = (BACK_AMPS_SENSOR_OFFSET - miscNodeData.panelAmpsBack * ADS1115_VPB) / ACS724_VPA;
 
                 if(miscNodeData.panelAmpsFrontA < 0){
-                    miscNodeData.panelAmpsFrontA = 0;
-                }
+					miscNodeData.panelAmpsFrontA = 0;
+				}
                 if(miscNodeData.panelAmpsFrontB < 0){
-                    miscNodeData.panelAmpsFrontB = 0;
-                }
+					miscNodeData.panelAmpsFrontB = 0;
+				}
                 if(miscNodeData.panelAmpsBack < 0){
-                    miscNodeData.panelAmpsBack = 0;
-                }
+					miscNodeData.panelAmpsBack = 0;
+				}
 
-                bmeTemp = miscNodeData.bmeTemp / 100.0;
-                bmePres = miscNodeData.bmePres / 100.0;
-                bmeHum = miscNodeData.bmeHum / 1000.0;
-                bmeGas = miscNodeData.bmeGas / 100.0;
+				bmeTemp = miscNodeData.bmeTemp / 100.0;
+				bmePres = miscNodeData.bmePres / 100.0;
+				bmeHum = miscNodeData.bmeHum / 1000.0;
+				bmeGas = miscNodeData.bmeGas / 100.0;
 
-                publishMiscData();
-            }
-            // If from another node/charge controller which is not reporting misc data.
+				publishMiscData();
+			}
+			// If from another node/charge controller which is not reporting misc data.
             else if(header.from_node - NUM_MISC_DATA_NODES <= NUM_CHARGE_CONTROLLERS && header.from_node > 0){
-                int index = header.from_node - (NUM_MISC_DATA_NODES + 1); // Need to subtract 1 extra because 0 is receiver node.
-                network.read(header, &chargeControllerNodeData[index], sizeof(chargeControllerNodeData[index]));
-                delay(10);
+				int index = header.from_node - (NUM_MISC_DATA_NODES + 1); // Need to subtract 1 extra because 0 is receiver node.
+				network.read(header, &chargeControllerNodeData[index], sizeof(chargeControllerNodeData[index]));
+				delay(10);
 
-                publishCC(index);
+				publishCC(index);
 
-                // Only refresh on one node since the display cannot refresh fast enough.
+				// Only refresh on one node since the display cannot refresh fast enough.
                 if(header.from_node == LCD_REFRESH_NODE){
-                    printLCD();
-                }
-            }
+					printLCD();
+				}
+			}
             else{
-                Serial.print(F("\nInvalid Sender: "));
-                Serial.println(header.from_node);
-                delay(INVALID_SENDER_DELAY);
-            }
-        }
-    }
+				Serial.print(F("\nInvalid Sender: "));
+				Serial.println(header.from_node);
+				delay(INVALID_SENDER_DELAY);
+			}
+		}
+	}
 }

--- a/Arduino-Version/My-Current-Seup/SOLAR_RECEIVE/SOLAR_RECEIVE.ino
+++ b/Arduino-Version/My-Current-Seup/SOLAR_RECEIVE/SOLAR_RECEIVE.ino
@@ -1,17 +1,17 @@
 /*
-	Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
+    Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
 
-	For my application there are four arduinos inside a deck box, three of them read data from a charge controller that is attached to it (CC1, CC2, CC3),
-	and the last one reads sensor data from a BME680 and a few ACS724 current sensors.
+    For my application there are four arduinos inside a deck box, three of them read data from a charge controller that is attached to it (CC1, CC2, CC3),
+    and the last one reads sensor data from a BME680 and a few ACS724 current sensors.
 
-	This ESP8266 then processes the data from the transmitters and then publishes it to an MQTT server as well as displays it on an attached LCD.
+    This ESP8266 then processes the data from the transmitters and then publishes it to an MQTT server as well as displays it on an attached LCD.
 
-	This code runs on an ESP8266 NODEMCU 0.9 module.
+    This code runs on an ESP8266 NODEMCU 0.9 module.
 
-	Attached components are:
-	- Generic 20x4 character I2C lcd display
-	- RF24 Module
-	- Capacitors on the 3.3V and 5V power rails to prevent voltage drops.
+    Attached components are:
+    - Generic 20x4 character I2C lcd display
+    - RF24 Module
+    - Capacitors on the 3.3V and 5V power rails to prevent voltage drops.
 */
 
 #include <RF24.h>              // Library version 1.3.12 works, 1.4.0 did not.
@@ -22,13 +22,13 @@
 // #include <math.h>              // Use this for pow().
 
 /*
-	WiFi Settings.
+    WiFi Settings.
 */
 #define WIFI_SSID "YOUR_WIFI_SSID"
 #define WIFI_PASS "YOUR_WIFI_PASSWORD"
 
 /*
-	MQTT related settings. You many need to change these depending on your implementation.
+    MQTT related settings. You many need to change these depending on your implementation.
 */
 #define MQTT_PORT 1883                   // Port to use for MQTT.
 #define MQTT_SERVER_ADDR "192.168.2.100" // Address of the MQTT server.
@@ -37,29 +37,29 @@
 #define NUM_MISC_MQTT_TOPICS 7           // Number of misc data related MQTT topics.
 
 /*
-	Offset of the ACS724 current sensors used for the misc data.
-	In theory these should be 2.5 but my sensors kinda suck.
-	Found experimentally, your numbers will differ.
+    Offset of the ACS724 current sensors used for the misc data.
+    In theory these should be 2.5 but my sensors kinda suck.
+    Found experimentally, your numbers will differ.
 */
 #define FRONT_AMPS_SENSOR_A_OFFSET 2.23
 #define FRONT_AMPS_SENSOR_B_OFFSET 2.36
 #define BACK_AMPS_SENSOR_OFFSET 2.40
 
 /*
-	Multipliers for the ADC and Current sensors.
+    Multipliers for the ADC and Current sensors.
 */
 #define ADS1115_VPB 0.0001875 // Volts per bit of the ADS1115 ADC (6.144V/32768).
 #define ACS724_VPA 0.066      // Volts per amp of the ACS724 current sensor.
 
 /*
-	I had issues with the transmitter's Serial buffers running out of room when receiving more than 29 registers at once
-	from the charge controller. Solved this by just sending two separate requests to get all the data I wanted.
+    I had issues with the transmitter's Serial buffers running out of room when receiving more than 29 registers at once
+    from the charge controller. Solved this by just sending two separate requests to get all the data I wanted.
 */
 #define NUM_REGISTERS_REQUEST1 24
 #define NUM_REGISTERS_REQUEST2 11
 
 /*
-	Other constant and settings.
+    Other constant and settings.
 */
 #define NUM_MISC_DATA_NODES 1      // Number of nodes which will be reporting misc data. Addresses of misc nodes must start counting up from 1. 
 #define NUM_CHARGE_CONTROLLERS 3   // Number of nodes that will report charge controller data. Addresses of charge controller nodes must start counting up from at NUM_MISC_DATA_NODES+1.
@@ -81,26 +81,26 @@
 #define WATTS_STRING_MAX_CHARS 6   // Maximum number of characters for the watts string for the lcd. Includes the W unit and null.
 
 /*
-	Structure for the charge controller data from the charge controller nodes.
+    Structure for the charge controller data from the charge controller nodes.
 */
 typedef struct package{
     uint16_t modbusErrDiff;                    // Number of new modbus errors since last transmission.
-	uint16_t request1[NUM_REGISTERS_REQUEST1]; // First group of registers from the charge controller
-	uint16_t request2[NUM_REGISTERS_REQUEST2]; // Second group of registers from the charge controller
+    uint16_t request1[NUM_REGISTERS_REQUEST1]; // First group of registers from the charge controller
+    uint16_t request2[NUM_REGISTERS_REQUEST2]; // Second group of registers from the charge controller
 }Package;
 Package chargeControllerNodeData[NUM_CHARGE_CONTROLLERS];
 
 /*
-	This is the structure which is transmitted from the misc data node to the receiver.
-	I have some other sensors I want to receive data from so I decided to separate them from the charge controller transmissions.
-	Front panel amps are split into two parts because the ACS724 only goes up to 30A and I needed 60A, so I placed two ACS724 sensors in parallel.
-	These are the raw sensor values and they need to be translated into their actual values later.
+    This is the structure which is transmitted from the misc data node to the receiver.
+    I have some other sensors I want to receive data from so I decided to separate them from the charge controller transmissions.
+    Front panel amps are split into two parts because the ACS724 only goes up to 30A and I needed 60A, so I placed two ACS724 sensors in parallel.
+    These are the raw sensor values and they need to be translated into their actual values later.
 */
 typedef struct package2{
-	float panelAmpsBack;   // Measured Back panel amps (ACS712 current sensor)
-	float panelAmpsFrontA; // Measured Front panel amps sensor 1/2 (ACS724 curent sensor)
-	float panelAmpsFrontB; // Measured Front panel amps sensor 1/2 (ACS724 curent sensor)
-	// float batteryVolts;     // Measured battery voltage (ADS1115 and a voltage divider. R1=56K, R2=10K) // Input 0 of my ADC is broken, enable if you need this.
+    float panelAmpsBack;   // Measured Back panel amps (ACS712 current sensor)
+    float panelAmpsFrontA; // Measured Front panel amps sensor 1/2 (ACS724 curent sensor)
+    float panelAmpsFrontB; // Measured Front panel amps sensor 1/2 (ACS724 curent sensor)
+    // float batteryVolts;     // Measured battery voltage (ADS1115 and a voltage divider. R1=56K, R2=10K) // Input 0 of my ADC is broken, enable if you need this.
     int32_t bmePres;       // Atmospheric pressure measured by BME680
     int32_t bmeTemp;       // Air temperature measured by BME680
     int32_t bmeHum;        // Air humidity measured by BME680
@@ -109,14 +109,14 @@ typedef struct package2{
 Package2 miscNodeData;
 
 /*
-	2D Array of pointers to make it easier to retrieve charge controller data.
+    2D Array of pointers to make it easier to retrieve charge controller data.
 */
 uint16_t* chargeControllerRegisterData[NUM_CHARGE_CONTROLLERS][NUM_REGISTERS_REQUEST1 + NUM_REGISTERS_REQUEST2];
 
 /*
-	Array of all MQTT topic names related to the charge controllers.
-	"CCX" will be appended to the start, X indicating the node/charge controller number.
-	You can change these as you see fit, just make sure whatever you are using to receive them also uses the same topic names.
+    Array of all MQTT topic names related to the charge controllers.
+    "CCX" will be appended to the start, X indicating the node/charge controller number.
+    You can change these as you see fit, just make sure whatever you are using to receive them also uses the same topic names.
 */
 const char* chargeControllerTopics[NUM_CC_MQTT_TOPICS]={
     "modbusErrDiff",        //0  Number of new modbus errors since last refresh.
@@ -144,9 +144,9 @@ const char* chargeControllerTopics[NUM_CC_MQTT_TOPICS]={
 };
 
 /*
-	Array of topics not related to the charge controller data.
-	These are sent by the misc data node.
-	These are treated by pub() as if their index is part of chargeControllerTopics.
+    Array of topics not related to the charge controller data.
+    These are sent by the misc data node.
+    These are treated by pub() as if their index is part of chargeControllerTopics.
 */
 const char* miscDataTopics[NUM_MISC_MQTT_TOPICS]={
     "dcAmpsB", //0 Direct measured Amps Back
@@ -159,8 +159,8 @@ const char* miscDataTopics[NUM_MISC_MQTT_TOPICS]={
 };
 
 /*
-	Array of charging mode strings.
-	These are the states the charge controller can be in when charging the battery.
+    Array of charging mode strings.
+    These are the states the charge controller can be in when charging the battery.
 */
 const char* chargeModes[7]={
     "OFF",             //0
@@ -173,7 +173,7 @@ const char* chargeModes[7]={
 };
 
 /*
-	Custom symbols for the LCD.
+    Custom symbols for the LCD.
 */
 byte omegaSymbol[] = { // Omega Symbol (Ohms)
     0x00,0x0E,0x11,0x11,0x11,0x0A,0x1B,0x00
@@ -183,12 +183,12 @@ byte degC[] = { // Degrees Celsius Symbol
 };
 
 /*
-	Hold converted bme readings.
+    Hold converted bme readings.
 */
 float bmePres, bmeTemp, bmeHum, bmeGas;
 
 /*
-	Used to avoid trying to publish data to mqtt if it failed to connect on startup.
+    Used to avoid trying to publish data to mqtt if it failed to connect on startup.
 */
 short mqttConnected;
 
@@ -205,194 +205,194 @@ PubSubClient client(MQTT_SERVER_ADDR, MQTT_PORT, wifiClient);
 
 void setup(){
     while (!Serial);
-	Serial.begin(115200);
+    Serial.begin(115200);
 
-	lcd.begin(); // Startup LCD
+    lcd.begin(); // Startup LCD
 
-	// Load custom characters into display ram.
-	lcd.createChar(0, omegaSymbol);
-	lcd.createChar(1, degC);
+    // Load custom characters into display ram.
+    lcd.createChar(0, omegaSymbol);
+    lcd.createChar(1, degC);
 
-	lcd.backlight(); // Turn on the LCD backlight
-	lcd.setCursor(0, 0);
-	lcd.print(F("Connecting"));
+    lcd.backlight(); // Turn on the LCD backlight
+    lcd.setCursor(0, 0);
+    lcd.print(F("Connecting"));
 
-	// Startup the RF24
+    // Startup the RF24
     while(!radio.begin()){
-		Serial.print(F("\nUnable to start RF24.\n"));
-		delay(SETUP_FAIL_DELAY);
-	}
-	network.begin(RF24_NETWORK_CHANNEL, RECEIVE_NODE_ADDR);
-	Serial.println(F("RF24 Initialized"));
+        Serial.print(F("\nUnable to start RF24.\n"));
+        delay(SETUP_FAIL_DELAY);
+    }
+    network.begin(RF24_NETWORK_CHANNEL, RECEIVE_NODE_ADDR);
+    Serial.println(F("RF24 Initialized"));
 
-	WiFi.begin(WIFI_SSID, WIFI_PASS); // Begin WiFi connection
-	// Wait for connection
-	int trys = 0;
+    WiFi.begin(WIFI_SSID, WIFI_PASS); // Begin WiFi connection
+    // Wait for connection
+    int trys = 0;
     while (WiFi.status() != WL_CONNECTED) {
         if(trys > WIFI_MAX_WAITS){
-			lcd.clear();
+            lcd.clear();
             lcd.setCursor(0, 0);
-			lcd.print(F("WiFi Disconnected :("));
-			lcd.setCursor(0, 1);
-			lcd.print(F("Skipping MQTT..."));
-			mqttConnected = 0;
-			break;
-		}
-		delay(WIFI_SINGLE_WAIT_DELAY);
-		Serial.print(F("."));
-		lcd.print(F("."));
-		trys++;
-	}
+            lcd.print(F("WiFi Disconnected :("));
+            lcd.setCursor(0, 1);
+            lcd.print(F("Skipping MQTT..."));
+            mqttConnected = 0;
+            break;
+        }
+        delay(WIFI_SINGLE_WAIT_DELAY);
+        Serial.print(F("."));
+        lcd.print(F("."));
+        trys++;
+    }
     if(WiFi.status() == WL_CONNECTED) {
-		lcd.clear();
-		lcd.setCursor(0, 0);
-		lcd.print(F("Connected :)"));
-		lcd.setCursor(0, 1);
-		lcd.print(F("SSID: "));
-		lcd.print(WIFI_SSID);
-		lcd.setCursor(0, 2);
-		lcd.print(F("IP: "));
-		lcd.print(WiFi.localIP());
-		lcd.setCursor(0, 3);
+        lcd.clear();
+        lcd.setCursor(0, 0);
+        lcd.print(F("Connected :)"));
+        lcd.setCursor(0, 1);
+        lcd.print(F("SSID: "));
+        lcd.print(WIFI_SSID);
+        lcd.setCursor(0, 2);
+        lcd.print(F("IP: "));
+        lcd.print(WiFi.localIP());
+        lcd.setCursor(0, 3);
 
-		Serial.print(F("\nConnected to "));
-		Serial.println(WIFI_SSID);
-		Serial.print(F("IP address: "));
-		Serial.println(WiFi.localIP());
+        Serial.print(F("\nConnected to "));
+        Serial.println(WIFI_SSID);
+        Serial.print(F("IP address: "));
+        Serial.println(WiFi.localIP());
 
-		// Connect to MQTT Broker
+        // Connect to MQTT Broker
         if (client.connect(MQTT_CLIENT_ID)) {
-			lcd.print(F("MQTT Connected :)"));
-			Serial.println(F("MQTT Connected"));
-			mqttConnected = 1;
-		}
+            lcd.print(F("MQTT Connected :)"));
+            Serial.println(F("MQTT Connected"));
+            mqttConnected = 1;
+        }
         else {
-			lcd.print(F("MQTT Failed :("));
-			Serial.println(F("MQTT Connection failed..."));
-			mqttConnected = 0;
-		}
-	}
+            lcd.print(F("MQTT Failed :("));
+            Serial.println(F("MQTT Connection failed..."));
+            mqttConnected = 0;
+        }
+    }
 
-	// Make a 2D array of pointers to make it easier to access the charge controller data.
-	// Initialize pointers array for request1 registers.
+    // Make a 2D array of pointers to make it easier to access the charge controller data.
+    // Initialize pointers array for request1 registers.
     for(int i = 0; i<NUM_REGISTERS_REQUEST1; i++){
         for(int j = 0; j<NUM_CHARGE_CONTROLLERS; j++){
-			chargeControllerRegisterData[j][i] = &chargeControllerNodeData[j].request1[i];
-		}
-	}
-	// Initialize pointers array for request2 registers.
+            chargeControllerRegisterData[j][i] = &chargeControllerNodeData[j].request1[i];
+        }
+    }
+    // Initialize pointers array for request2 registers.
     for(int i = 0; i<NUM_REGISTERS_REQUEST2; i++){
         for(int j = 0; j<NUM_CHARGE_CONTROLLERS; j++){
-			chargeControllerRegisterData[j][i + NUM_REGISTERS_REQUEST1] = &chargeControllerNodeData[j].request2[i];
-		}
-	}
+            chargeControllerRegisterData[j][i + NUM_REGISTERS_REQUEST1] = &chargeControllerNodeData[j].request2[i];
+        }
+    }
 
-	bmePres = bmeTemp = bmeHum = bmeGas = 0;
+    bmePres = bmeTemp = bmeHum = bmeGas = 0;
 
-	delay(1500); // Give enough time to read the details from the display.
+    delay(1500); // Give enough time to read the details from the display.
 }
 
 /*
-	Helper function to handle the sign bit for negative temperatures.
+    Helper function to handle the sign bit for negative temperatures.
 */
 int getRealTemp(int temp){
     return temp/128 ? -(temp%128) : temp;
 }
 
 /*
-	Generate the watts string to be printed on the LCD
-	When nodeId is negative then calculate the total across all charge controllers.
+    Generate the watts string to be printed on the LCD
+    When nodeId is negative then calculate the total across all charge controllers.
 */
 void getWattsForDisplay(char* wattsString, int nodeId){
-	int watts = 0;
+    int watts = 0;
 
-	// Calculate the total across all charge controllers.
+    // Calculate the total across all charge controllers.
     if(nodeId < 0){
         for(int i = 0; i<NUM_CHARGE_CONTROLLERS; i++){
             if(!chargeControllerNodeData[i].modbusErrDiff){
-				watts += (int)(*chargeControllerRegisterData[i][9]);
-			}
-		}
-	}
-	// Is the charge controller offline?
+                watts += (int)(*chargeControllerRegisterData[i][9]);
+            }
+        }
+    }
+    // Is the charge controller offline?
     else if(chargeControllerNodeData[nodeId].modbusErrDiff){
-		snprintf(wattsString, WATTS_STRING_MAX_CHARS, "----W");
-		return;
-	}
+        snprintf(wattsString, WATTS_STRING_MAX_CHARS, "----W");
+        return;
+    }
     else{
-		watts = (int)(*chargeControllerRegisterData[nodeId][9]);
-	}
+        watts = (int)(*chargeControllerRegisterData[nodeId][9]);
+    }
 
-	snprintf(wattsString, WATTS_STRING_MAX_CHARS, "%dW", watts);
+    snprintf(wattsString, WATTS_STRING_MAX_CHARS, "%dW", watts);
 
-	// Generate the correct spacing after the watts number.
+    // Generate the correct spacing after the watts number.
     if(watts < 10){
-		char space[4] = "   ";
-		strncat(wattsString, space, 3);
-	}
+        char space[4] = "   ";
+        strncat(wattsString, space, 3);
+    }
     else{
-		char space[2] = " ";
+        char space[2] = " ";
         while(watts/1000 == 0){
-			watts *= 10;
-			strncat(wattsString, space, 1);
-		}
-	}
+            watts *= 10;
+            strncat(wattsString, space, 1);
+        }
+    }
 }
 
 /*
-	Print data to the attached LCD.
+    Print data to the attached LCD.
 */
 void printLCD(){
-	// Prepare display contents before we clear the display.
-	// By doing this we decrease how long the display blanks for.
+    // Prepare display contents before we clear the display.
+    // By doing this we decrease how long the display blanks for.
 
     char* wattsString = (char*)malloc(WATTS_STRING_MAX_CHARS);
 
-	// T: XXXXW Bat: XX.XV
-	char row1[ROW_1_MAX_CHARS];
-	getWattsForDisplay(wattsString, -1); // Get total watts.
+    // T: XXXXW Bat: XX.XV
+    char row1[ROW_1_MAX_CHARS];
+    getWattsForDisplay(wattsString, -1); // Get total watts.
     snprintf(row1, sizeof(row1), "T:%s Bat: %.1fV", wattsString, *chargeControllerRegisterData[2][1]*0.1);
 
-	// E:XXXXW Tmp: XX.XX°C (°C is written later)
-	char row2[ROW_2_MAX_CHARS];
-	getWattsForDisplay(wattsString, 0); // Get CC1 watts.
-	snprintf(row2, sizeof(row2), "F:%s Tmp: %.2f", wattsString, bmeTemp);
+    // E:XXXXW Tmp: XX.XX°C (°C is written later)
+    char row2[ROW_2_MAX_CHARS];
+    getWattsForDisplay(wattsString, 0); // Get CC1 watts.
+    snprintf(row2, sizeof(row2), "F:%s Tmp: %.2f", wattsString, bmeTemp);
 
-	// S:XXXXW Hum: XX%
-	char row3[ROW_3_MAX_CHARS];
-	getWattsForDisplay(wattsString, 1); // Get CC2 watts.
-	snprintf(row3, sizeof(row3), "S:%s Hum: %d%%", wattsString, (int)bmeHum);
+    // S:XXXXW Hum: XX%
+    char row3[ROW_3_MAX_CHARS];
+    getWattsForDisplay(wattsString, 1); // Get CC2 watts.
+    snprintf(row3, sizeof(row3), "S:%s Hum: %d%%", wattsString, (int)bmeHum);
 
-	// W:XXXXW Gas: XXXXX
+    // W:XXXXW Gas: XXXXX
     char row4[ROW_4_PART1_MAX_CHARS+ROW_4_PART2_MAX_CHARS-1]; // -1 because part 1 includes null that is overwritten.
     getWattsForDisplay(wattsString, 2); // Get CC3 watts.
-	snprintf(row4, ROW_4_PART1_MAX_CHARS, "B:%s Gas: ", wattsString);
+    snprintf(row4, ROW_4_PART1_MAX_CHARS, "B:%s Gas: ", wattsString);
     if(bmeGas >= 10000){
         snprintf(&row4[13], ROW_4_PART2_MAX_CHARS, "%dM", (int)bmeGas/1000);
-	}
+    }
     else{
-		snprintf(&row4[13], ROW_4_PART2_MAX_CHARS, "%dk", (int)bmeGas);
-	}
+        snprintf(&row4[13], ROW_4_PART2_MAX_CHARS, "%dk", (int)bmeGas);
+    }
 
-	// Clear the display and start writing to it.
-	lcd.clear();
+    // Clear the display and start writing to it.
+    lcd.clear();
 
-	lcd.print(row1);
+    lcd.print(row1);
 
-	lcd.setCursor(0, 1);
-	lcd.print(row2);
-	lcd.setCursor((int)(strlen(&row2[0])), 1);
-	lcd.write(1); // Write the degC symbol (degrees Celsius)
+    lcd.setCursor(0, 1);
+    lcd.print(row2);
+    lcd.setCursor((int)(strlen(&row2[0])), 1);
+    lcd.write(1); // Write the degC symbol (degrees Celsius)
 
-	lcd.setCursor(0, 2);
-	lcd.print(row3);
+    lcd.setCursor(0, 2);
+    lcd.print(row3);
 
-	lcd.setCursor(0, 3);
-	lcd.print(row4);
-	lcd.setCursor((int)(strlen(&row4[0])), 3);
-	lcd.write(0); // Write the omega symbol (Ohm)
+    lcd.setCursor(0, 3);
+    lcd.print(row4);
+    lcd.setCursor((int)(strlen(&row4[0])), 3);
+    lcd.write(0); // Write the omega symbol (Ohm)
 
-	free(wattsString);
+    free(wattsString);
 }
 
 // Function to correct the voltage measurement. Found experimentally, will differ by setup.
@@ -402,233 +402,233 @@ void printLCD(){
 // }
 
 /*
-	Publish MQTT data that is not misc data.
-	topicIndex is the index of the topic name, val is the actual data value, nodeId indicates which node the data came from.
+    Publish MQTT data that is not misc data.
+    topicIndex is the index of the topic name, val is the actual data value, nodeId indicates which node the data came from.
 */
 void pub(int topicIndex, float val, int nodeId=0){
-	// Build the topic name.
+    // Build the topic name.
     char* tempTopic;
-	// If the topicIndex is outside the range of the charge controller topics, switch to misc data topics.
+    // If the topicIndex is outside the range of the charge controller topics, switch to misc data topics.
     if(topicIndex >= NUM_CC_MQTT_TOPICS){
         int topicSize = strlen(miscDataTopics[topicIndex - NUM_CC_MQTT_TOPICS])+1; // +1 for null terminator.
         tempTopic = (char*)malloc(topicSize);
-		snprintf(tempTopic, topicSize, "%s", miscDataTopics[topicIndex - NUM_CC_MQTT_TOPICS]);
-	}
+        snprintf(tempTopic, topicSize, "%s", miscDataTopics[topicIndex - NUM_CC_MQTT_TOPICS]);
+    }
     else{
-		int topicSize = strlen(chargeControllerTopics[topicIndex]) + strlen(CC_TOPIC_PREFIX) + 2; // +1 for null terminator and +1 for the charge controller number after the CC prefix. >9 will need adjustment.
+        int topicSize = strlen(chargeControllerTopics[topicIndex]) + strlen(CC_TOPIC_PREFIX) + 2; // +1 for null terminator and +1 for the charge controller number after the CC prefix. >9 will need adjustment.
         tempTopic = (char*)malloc(topicSize);
-		snprintf(tempTopic, topicSize, "%s%d%s", CC_TOPIC_PREFIX, nodeId + 1, chargeControllerTopics[topicIndex]);
-	}
+        snprintf(tempTopic, topicSize, "%s%d%s", CC_TOPIC_PREFIX, nodeId + 1, chargeControllerTopics[topicIndex]);
+    }
 
-	// Is this the charging mode topic?
+    // Is this the charging mode topic?
     if(topicIndex == CHARGE_MODE_TOPIC_INDEX){
-		// See if load is turned on, if it is then we need to apply an offset since they share a register.
-		int loadOffset = *chargeControllerRegisterData[nodeId][32] > 6 ? 32768 : 0;
+        // See if load is turned on, if it is then we need to apply an offset since they share a register.
+        int loadOffset = *chargeControllerRegisterData[nodeId][32] > 6 ? 32768 : 0;
 
         if(!client.publish(tempTopic, chargeModes[*chargeControllerRegisterData[nodeId][32] - loadOffset])){
-			// If error then try reconnecting and publishing again.
+            // If error then try reconnecting and publishing again.
             if(client.connect(MQTT_CLIENT_ID)){
-				client.publish(tempTopic, chargeModes[*chargeControllerRegisterData[nodeId][32] - loadOffset]);
-			}
-		}
-	}
+                client.publish(tempTopic, chargeModes[*chargeControllerRegisterData[nodeId][32] - loadOffset]);
+            }
+        }
+    }
     else{
-		char tempVal[16];
+        char tempVal[16];
 
-		// Is this the modbus error topic?
+        // Is this the modbus error topic?
         if(topicIndex == MODBUS_ERR_TOPIC_INDEX){
-			snprintf(tempVal, sizeof(tempVal), "%d", chargeControllerNodeData[nodeId].modbusErrDiff);
-		}
+            snprintf(tempVal, sizeof(tempVal), "%d", chargeControllerNodeData[nodeId].modbusErrDiff);
+        }
         else{
             snprintf(tempVal, sizeof(tempVal),"%f", val);
-		}
+        }
 
         if(!client.publish(tempTopic, tempVal)){
-			// If error then try reconnecting and publishing again.
-			Serial.println(F("Data not sent\n"));
+            // If error then try reconnecting and publishing again.
+            Serial.println(F("Data not sent\n"));
             if(client.connect(MQTT_CLIENT_ID)){
-				client.publish(tempTopic, tempVal);
-			}
-		}
-	}
-	free(tempTopic);
+                client.publish(tempTopic, tempVal);
+            }
+        }
+    }
+    free(tempTopic);
 }
 
 // Coordinate publishing the misc data which is not from the charge controllers.
 void publishMiscData(){
-	if (!mqttConnected)
-		return; // Handle case where mqtt connection failed at initial startup, no point int trying to connect.
+    if (!mqttConnected)
+        return; // Handle case where mqtt connection failed at initial startup, no point int trying to connect.
 
-	pub(0 + NUM_CC_MQTT_TOPICS, miscNodeData.panelAmpsBack);
-	pub(1 + NUM_CC_MQTT_TOPICS, miscNodeData.panelAmpsFrontA + miscNodeData.panelAmpsFrontB);
-	// pub(2 + NUM_CC_MQTT_TOPICS, miscNodeData.dcVolts); // Input 0 of my ADC is broken, enable if you need this.
-	pub(3 + NUM_CC_MQTT_TOPICS, bmeTemp);
-	pub(4 + NUM_CC_MQTT_TOPICS, bmeHum);
-	pub(5 + NUM_CC_MQTT_TOPICS, bmePres);
-	pub(6 + NUM_CC_MQTT_TOPICS, bmeGas);
+    pub(0 + NUM_CC_MQTT_TOPICS, miscNodeData.panelAmpsBack);
+    pub(1 + NUM_CC_MQTT_TOPICS, miscNodeData.panelAmpsFrontA + miscNodeData.panelAmpsFrontB);
+    // pub(2 + NUM_CC_MQTT_TOPICS, miscNodeData.dcVolts); // Input 0 of my ADC is broken, enable if you need this.
+    pub(3 + NUM_CC_MQTT_TOPICS, bmeTemp);
+    pub(4 + NUM_CC_MQTT_TOPICS, bmeHum);
+    pub(5 + NUM_CC_MQTT_TOPICS, bmePres);
+    pub(6 + NUM_CC_MQTT_TOPICS, bmeGas);
 }
 
 /*
-	Coordinate publishing all charge controller data. nodeId is the address of the charge controller node - (NUM_MISC_DATA_NODES+1).
-	Register addresses were figured out from the modbus document, have a look at it if you are confused about them.
+    Coordinate publishing all charge controller data. nodeId is the address of the charge controller node - (NUM_MISC_DATA_NODES+1).
+    Register addresses were figured out from the modbus document, have a look at it if you are confused about them.
 */
 void publishCC(int nodeId){
     if(!mqttConnected) return; // Handle case where mqtt connection failed at initial startup, no point int trying to connect.
 
-	// Publish modbus error
-	pub(0, 0, nodeId);
+    // Publish modbus error
+    pub(0, 0, nodeId);
 
-	// Publish the charging mode of the charge controller.
-	pub(1, 0, nodeId);
+    // Publish the charging mode of the charge controller.
+    pub(1, 0, nodeId);
 
-	// Publish battery state of charge.
-	pub(2, *chargeControllerRegisterData[nodeId][0], nodeId);
+    // Publish battery state of charge.
+    pub(2, *chargeControllerRegisterData[nodeId][0], nodeId);
 
-	// Publish battery volts.
+    // Publish battery volts.
     pub(3, (*chargeControllerRegisterData[nodeId][1]*0.1), nodeId);
 
-	// Publish battery charging current.
+    // Publish battery charging current.
     pub(4, (*chargeControllerRegisterData[nodeId][2]*0.01), nodeId);
 
-	// Publish controller temperature.
-	pub(5, getRealTemp(*chargeControllerRegisterData[nodeId][3] >> 8), nodeId); // Controller and battery temps share a single register.
+    // Publish controller temperature.
+    pub(5, getRealTemp(*chargeControllerRegisterData[nodeId][3] >> 8), nodeId); // Controller and battery temps share a single register.
 
-	// Publish battery temperature.
-	pub(6, getRealTemp(*chargeControllerRegisterData[nodeId][3] & 0xFF), nodeId);
+    // Publish battery temperature.
+    pub(6, getRealTemp(*chargeControllerRegisterData[nodeId][3] & 0xFF), nodeId);
 
-	// // Publish load voltage.
-	// pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][4]*0.1), nodeId);
-	// // Publish load current.
-	// pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][5]*0.01), nodeId);
-	// // Publish load wattage.
-	// pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][6]), nodeId);
+    // // Publish load voltage.
+    // pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][4]*0.1), nodeId);
+    // // Publish load current.
+    // pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][5]*0.01), nodeId);
+    // // Publish load wattage.
+    // pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][6]), nodeId);
 
-	// Publish battery volts.
+    // Publish battery volts.
     pub(7, (*chargeControllerRegisterData[nodeId][7]*0.1), nodeId);
 
-	// Publish panel current.
+    // Publish panel current.
     pub(8, (*chargeControllerRegisterData[nodeId][8]*0.01), nodeId);
 
-	// Publish panel watts.
-	pub(9, *chargeControllerRegisterData[nodeId][9], nodeId);
+    // Publish panel watts.
+    pub(9, *chargeControllerRegisterData[nodeId][9], nodeId);
 
-	// // Publish load status (on / off).
-	// pub(TOPIC_ID_HERE, *chargeControllerRegisterData[nodeId][10], nodeId);
+    // // Publish load status (on / off).
+    // pub(TOPIC_ID_HERE, *chargeControllerRegisterData[nodeId][10], nodeId);
 
-	// Publish battery daily min volts.
+    // Publish battery daily min volts.
     pub(10, (*chargeControllerRegisterData[nodeId][11]*0.1), nodeId);
 
-	// Publish battery daily max volts.
+    // Publish battery daily max volts.
     pub(11, (*chargeControllerRegisterData[nodeId][12]*0.1), nodeId);
 
-	// Publish battery daily max charging current.
+    // Publish battery daily max charging current.
     pub(12, (*chargeControllerRegisterData[nodeId][13]*0.01), nodeId);
 
-	// // Publish daily max load current.
-	// pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][14]*0.01), nodeId);
+    // // Publish daily max load current.
+    // pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][14]*0.01), nodeId);
 
-	// Publish daily max panel charging power.
-	pub(13, *chargeControllerRegisterData[nodeId][15], nodeId);
+    // Publish daily max panel charging power.
+    pub(13, *chargeControllerRegisterData[nodeId][15], nodeId);
 
-	// // Publish daily max load power.
-	// pub(TOPIC_ID_HERE, *chargeControllerRegisterData[nodeId][16], nodeId);
+    // // Publish daily max load power.
+    // pub(TOPIC_ID_HERE, *chargeControllerRegisterData[nodeId][16], nodeId);
 
-	// Publish daily charging amp hours.
-	pub(14, *chargeControllerRegisterData[nodeId][17], nodeId);
+    // Publish daily charging amp hours.
+    pub(14, *chargeControllerRegisterData[nodeId][17], nodeId);
 
-	// // Publish daily load amp hours.
-	// pub(TOPIC_ID_HERE, *chargeControllerRegisterData[nodeId][18], inodeIdd);
+    // // Publish daily load amp hours.
+    // pub(TOPIC_ID_HERE, *chargeControllerRegisterData[nodeId][18], inodeIdd);
 
-	// Publish daily power generated.
+    // Publish daily power generated.
     pub(15, (*chargeControllerRegisterData[nodeId][19]*0.001), nodeId);
 
-	// // Publish daily load power used.
-	// pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][20]*0.001), nodeId);
+    // // Publish daily load power used.
+    // pub(TOPIC_ID_HERE, (*chargeControllerRegisterData[nodeId][20]*0.001), nodeId);
 
-	// Publish number of days operational
-	pub(16, *chargeControllerRegisterData[nodeId][21], nodeId);
+    // Publish number of days operational
+    pub(16, *chargeControllerRegisterData[nodeId][21], nodeId);
 
-	// Publish number of battery over-discharges
-	pub(17, *chargeControllerRegisterData[nodeId][22], nodeId);
+    // Publish number of battery over-discharges
+    pub(17, *chargeControllerRegisterData[nodeId][22], nodeId);
 
-	// Publish number of battery full-charges
-	pub(18, *chargeControllerRegisterData[nodeId][23], nodeId);
+    // Publish number of battery full-charges
+    pub(18, *chargeControllerRegisterData[nodeId][23], nodeId);
 
-	// Publish total battery charging amp-hours.
+    // Publish total battery charging amp-hours.
     pub(19, ((*chargeControllerRegisterData[nodeId][24]*65536 + *chargeControllerRegisterData[nodeId][25])*0.001), nodeId);
 
-	// // Publish total load consumption amp-hours.
-	// pub(TOPIC_ID_HERE, ((*chargeControllerRegisterData[nodeId][26]*65536 + *chargeControllerRegisterData[nodeId][27])*0.001), nodeId);
+    // // Publish total load consumption amp-hours.
+    // pub(TOPIC_ID_HERE, ((*chargeControllerRegisterData[nodeId][26]*65536 + *chargeControllerRegisterData[nodeId][27])*0.001), nodeId);
 
-	// Publish total power generation.
+    // Publish total power generation.
     pub(20, ((*chargeControllerRegisterData[nodeId][28]*65536 + *chargeControllerRegisterData[nodeId][29])*0.001), nodeId);
 
-	// // Publish total load power consumption.
-	// pub(TOPIC_ID_HERE, ((*chargeControllerRegisterData[nodeId][30]*65536 + *chargeControllerRegisterData[nodeId][31])*0.001), nodeId);
+    // // Publish total load power consumption.
+    // pub(TOPIC_ID_HERE, ((*chargeControllerRegisterData[nodeId][30]*65536 + *chargeControllerRegisterData[nodeId][31])*0.001), nodeId);
 
-	// Register 32 is charging state which is handled in the first pub() call, 33 is reserved.
+    // Register 32 is charging state which is handled in the first pub() call, 33 is reserved.
 
-	// Publish fault data.
-	pub(21, *chargeControllerRegisterData[nodeId][34], nodeId);
+    // Publish fault data.
+    pub(21, *chargeControllerRegisterData[nodeId][34], nodeId);
 }
 
 void loop(){
-	network.update();
+    network.update();
     if(network.available()){
         while(network.available()){
-			RF24NetworkHeader header;
-			network.peek(header);
+            RF24NetworkHeader header;
+            network.peek(header);
 
-			// See which node this transmission is from.
-			// If from a node reporting misc data, treat differently.
+            // See which node this transmission is from.
+            // If from a node reporting misc data, treat differently.
             if(header.from_node <= NUM_MISC_DATA_NODES && header.from_node > 0){
-				// If multiple misc data nodes you may mant to treat them differently here.
-				// For my application I only have 1 misc node so I won't do that.
+                // If multiple misc data nodes you may mant to treat them differently here.
+                // For my application I only have 1 misc node so I won't do that.
 
-				network.read(header, &miscNodeData, sizeof(miscNodeData));
-				delay(10);
+                network.read(header, &miscNodeData, sizeof(miscNodeData));
+                delay(10);
 
-				// Convert the raw sensor data values from the transmitter into their actual values.
-				// miscNodeData.dcVolts = voltApprox(miscNodeData.dcVolts*ADS1115_VPB); // Input 0 of my ADC is broken, enable if you need this.
-				miscNodeData.panelAmpsFrontA = (FRONT_AMPS_SENSOR_A_OFFSET - miscNodeData.panelAmpsFrontA * ADS1115_VPB) / ACS724_VPA;
-				miscNodeData.panelAmpsFrontB = (FRONT_AMPS_SENSOR_B_OFFSET - miscNodeData.panelAmpsFrontB * ADS1115_VPB) / ACS724_VPA;
-				miscNodeData.panelAmpsBack = (BACK_AMPS_SENSOR_OFFSET - miscNodeData.panelAmpsBack * ADS1115_VPB) / ACS724_VPA;
+                // Convert the raw sensor data values from the transmitter into their actual values.
+                // miscNodeData.dcVolts = voltApprox(miscNodeData.dcVolts*ADS1115_VPB); // Input 0 of my ADC is broken, enable if you need this.
+                miscNodeData.panelAmpsFrontA = (FRONT_AMPS_SENSOR_A_OFFSET - miscNodeData.panelAmpsFrontA * ADS1115_VPB) / ACS724_VPA;
+                miscNodeData.panelAmpsFrontB = (FRONT_AMPS_SENSOR_B_OFFSET - miscNodeData.panelAmpsFrontB * ADS1115_VPB) / ACS724_VPA;
+                miscNodeData.panelAmpsBack = (BACK_AMPS_SENSOR_OFFSET - miscNodeData.panelAmpsBack * ADS1115_VPB) / ACS724_VPA;
 
                 if(miscNodeData.panelAmpsFrontA < 0){
-					miscNodeData.panelAmpsFrontA = 0;
-				}
+                    miscNodeData.panelAmpsFrontA = 0;
+                }
                 if(miscNodeData.panelAmpsFrontB < 0){
-					miscNodeData.panelAmpsFrontB = 0;
-				}
+                    miscNodeData.panelAmpsFrontB = 0;
+                }
                 if(miscNodeData.panelAmpsBack < 0){
-					miscNodeData.panelAmpsBack = 0;
-				}
+                    miscNodeData.panelAmpsBack = 0;
+                }
 
-				bmeTemp = miscNodeData.bmeTemp / 100.0;
-				bmePres = miscNodeData.bmePres / 100.0;
-				bmeHum = miscNodeData.bmeHum / 1000.0;
-				bmeGas = miscNodeData.bmeGas / 100.0;
+                bmeTemp = miscNodeData.bmeTemp / 100.0;
+                bmePres = miscNodeData.bmePres / 100.0;
+                bmeHum = miscNodeData.bmeHum / 1000.0;
+                bmeGas = miscNodeData.bmeGas / 100.0;
 
-				publishMiscData();
-			}
-			// If from another node/charge controller which is not reporting misc data.
+                publishMiscData();
+            }
+            // If from another node/charge controller which is not reporting misc data.
             else if(header.from_node - NUM_MISC_DATA_NODES <= NUM_CHARGE_CONTROLLERS && header.from_node > 0){
-				int index = header.from_node - (NUM_MISC_DATA_NODES + 1); // Need to subtract 1 extra because 0 is receiver node.
-				network.read(header, &chargeControllerNodeData[index], sizeof(chargeControllerNodeData[index]));
-				delay(10);
+                int index = header.from_node - (NUM_MISC_DATA_NODES + 1); // Need to subtract 1 extra because 0 is receiver node.
+                network.read(header, &chargeControllerNodeData[index], sizeof(chargeControllerNodeData[index]));
+                delay(10);
 
-				publishCC(index);
+                publishCC(index);
 
-				// Only refresh on one node since the display cannot refresh fast enough.
+                // Only refresh on one node since the display cannot refresh fast enough.
                 if(header.from_node == LCD_REFRESH_NODE){
-					printLCD();
-				}
-			}
+                    printLCD();
+                }
+            }
             else{
-				Serial.print(F("\nInvalid Sender: "));
-				Serial.println(header.from_node);
-				delay(INVALID_SENDER_DELAY);
-			}
-		}
-	}
+                Serial.print(F("\nInvalid Sender: "));
+                Serial.println(header.from_node);
+                delay(INVALID_SENDER_DELAY);
+            }
+        }
+    }
 }

--- a/Arduino-Version/My-Current-Seup/SOLAR_SEND_CC1/SOLAR_SEND_CC1.ino
+++ b/Arduino-Version/My-Current-Seup/SOLAR_SEND_CC1/SOLAR_SEND_CC1.ino
@@ -14,7 +14,7 @@
 #include <avr/wdt.h>        // Watchdog timer.
 
 /*
-	Pins to use for software serial for talking to the charge controller through the MAX3232.
+    Pins to use for software serial for talking to the charge controller through the MAX3232.
 */
 #define MAX3232_RX 2 // RX pin.
 #define MAX3232_TX 3 // TX pin.
@@ -36,9 +36,9 @@
     Modbus Constants
 */
 /*
-	All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
-	The library I use will not work with address 255 initially and must be modified, see the README for details.
-	You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
+    All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
+    The library I use will not work with address 255 initially and must be modified, see the README for details.
+    You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
 */
 #define MODBUS_SLAVE_ADDR 255
 #define MODBUS_READ_CODE 3
@@ -53,6 +53,8 @@
 #define THIS_NODE_ADDR 2                       // Address of this node.
 #define RF24_NETWORK_CHANNEL 90                // Channel the RF24 network should use.
 #define REQUEST_DELAY 2000                     // Delay in ms between requests to the charge controller over modbus.
+#define REQUEST_DELAY_JITTER_MIN 0             // Minimum delay jitter in ms between requests. (Avoid nodes constantly transmitting at the same time).
+#define REQUEST_DELAY_JITTER_MAX 200           // Maximum delay jitter in ms between requests. (Avoid nodes constantly transmitting at the same time).
 #define SETUP_FAIL_DELAY 2000                  // Delay when retrying setup tasks.
 #define SETUP_FINISH_DELAY 100*THIS_NODE_ADDR  // Delay after finishing setup. (Multiplied by address to to avoid interference on startup).
 
@@ -71,8 +73,8 @@ enum STATE {
 STATE state;
 
 unsigned long lastTime; // Last time isTime() was run and returned 1.
-
 uint16_t lastErrCnt; // Used to keep tract of modbus errors so we can compare to see how many new errors were generated.
+long requestDelayJitter; // Used to help make transmitters not constantly transmit at the same time.
 
 // Create the RF24 radio and network.
 RF24 radio(9, 10); // CE, CSN
@@ -130,7 +132,10 @@ void setup(){
     master.setTimeOut(MODBUS_MASTER_TIMEOUT);
     lastTime = millis();
     lastErrCnt = 0;
-    state = WAIT_REQUEST1; 
+    state = WAIT_REQUEST1;
+
+    randomSeed(analogRead(0));
+    requestDelayJitter = getNewDelayJitter();
 
     delay(SETUP_FINISH_DELAY);
 
@@ -139,10 +144,17 @@ void setup(){
 }
 
 /*
+    Generate a new random request delay jitter.
+*/
+long getNewDelayJitter(){
+    return random(REQUEST_DELAY_JITTER_MIN, REQUEST_DELAY_JITTER_MAX);
+}
+
+/*
     millis() Rollover safe time delay tracking.
 */
 uint8_t isTime(){
-    if(millis() - lastTime >= REQUEST_DELAY){
+    if(millis() - lastTime >= REQUEST_DELAY + requestDelayJitter){
         lastTime = millis();
         return 1;
     }
@@ -203,6 +215,8 @@ void loop(){
         RF24NetworkHeader header(RECEIVE_NODE_ADDR);
         network.write(header, &data, sizeof(data));
         delay(10);
+
+        requestDelayJitter = getNewDelayJitter();
 
         // Return to original state.
         state = WAIT_REQUEST1;

--- a/Arduino-Version/My-Current-Seup/SOLAR_SEND_CC1/SOLAR_SEND_CC1.ino
+++ b/Arduino-Version/My-Current-Seup/SOLAR_SEND_CC1/SOLAR_SEND_CC1.ino
@@ -1,5 +1,5 @@
 /*
-    Cole L - 19th November 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
+    Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
     
     This arduino is responsible for reporting the data from the first charge controller (FRONT).
     
@@ -35,7 +35,12 @@
 /*
     Modbus Constants
 */
-#define MODBUS_SLAVE_ADDR 1
+/*
+	All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
+	The library I use will not work with address 255 initially and must be modified, see the README for details.
+	You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
+*/
+#define MODBUS_SLAVE_ADDR 255
 #define MODBUS_READ_CODE 3
 #define MODBUS_REQUEST1_START_ADDR 256
 #define MODBUS_REQUEST2_START_ADDR 280

--- a/Arduino-Version/My-Current-Seup/SOLAR_SEND_CC2/SOLAR_SEND_CC2.ino
+++ b/Arduino-Version/My-Current-Seup/SOLAR_SEND_CC2/SOLAR_SEND_CC2.ino
@@ -14,7 +14,7 @@
 #include <avr/wdt.h>        // Watchdog timer.
 
 /*
-	Pins to use for software serial for talking to the charge controller through the MAX3232.
+    Pins to use for software serial for talking to the charge controller through the MAX3232.
 */
 #define MAX3232_RX 2 // RX pin.
 #define MAX3232_TX 3 // TX pin.
@@ -36,9 +36,9 @@
     Modbus Constants
 */
 /*
-	All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
-	The library I use will not work with address 255 initially and must be modified, see the README for details.
-	You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
+    All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
+    The library I use will not work with address 255 initially and must be modified, see the README for details.
+    You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
 */
 #define MODBUS_SLAVE_ADDR 255
 #define MODBUS_READ_CODE 3
@@ -53,6 +53,8 @@
 #define THIS_NODE_ADDR 3                       // Address of this node.
 #define RF24_NETWORK_CHANNEL 90                // Channel the RF24 network should use.
 #define REQUEST_DELAY 2000                     // Delay in ms between requests to the charge controller over modbus.
+#define REQUEST_DELAY_JITTER_MIN 0             // Minimum delay jitter in ms between requests. (Avoid nodes constantly transmitting at the same time).
+#define REQUEST_DELAY_JITTER_MAX 200           // Maximum delay jitter in ms between requests. (Avoid nodes constantly transmitting at the same time).
 #define SETUP_FAIL_DELAY 2000                  // Delay when retrying setup tasks.
 #define SETUP_FINISH_DELAY 100*THIS_NODE_ADDR  // Delay after finishing setup. (Multiplied by address to to avoid interference on startup).
 
@@ -71,8 +73,8 @@ enum STATE {
 STATE state;
 
 unsigned long lastTime; // Last time isTime() was run and returned 1.
-
 uint16_t lastErrCnt; // Used to keep tract of modbus errors so we can compare to see how many new errors were generated.
+long requestDelayJitter; // Used to help make transmitters not constantly transmit at the same time.
 
 // Create the RF24 radio and network.
 RF24 radio(9, 10); // CE, CSN
@@ -130,7 +132,10 @@ void setup(){
     master.setTimeOut(MODBUS_MASTER_TIMEOUT);
     lastTime = millis();
     lastErrCnt = 0;
-    state = WAIT_REQUEST1; 
+    state = WAIT_REQUEST1;
+
+    randomSeed(analogRead(0));
+    requestDelayJitter = getNewDelayJitter();
 
     delay(SETUP_FINISH_DELAY);
 
@@ -139,10 +144,17 @@ void setup(){
 }
 
 /*
+    Generate a new random request delay jitter.
+*/
+long getNewDelayJitter(){
+    return random(REQUEST_DELAY_JITTER_MIN, REQUEST_DELAY_JITTER_MAX);
+}
+
+/*
     millis() Rollover safe time delay tracking.
 */
 uint8_t isTime(){
-    if(millis() - lastTime >= REQUEST_DELAY){
+    if(millis() - lastTime >= REQUEST_DELAY + requestDelayJitter){
         lastTime = millis();
         return 1;
     }
@@ -203,6 +215,8 @@ void loop(){
         RF24NetworkHeader header(RECEIVE_NODE_ADDR);
         network.write(header, &data, sizeof(data));
         delay(10);
+
+        requestDelayJitter = getNewDelayJitter();
 
         // Return to original state.
         state = WAIT_REQUEST1;

--- a/Arduino-Version/My-Current-Seup/SOLAR_SEND_CC2/SOLAR_SEND_CC2.ino
+++ b/Arduino-Version/My-Current-Seup/SOLAR_SEND_CC2/SOLAR_SEND_CC2.ino
@@ -1,5 +1,5 @@
 /*
-    Cole L - 19th November 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
+    Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
     
     This arduino is responsible for reporting the data from the second charge controller (SIDE).
     
@@ -35,7 +35,12 @@
 /*
     Modbus Constants
 */
-#define MODBUS_SLAVE_ADDR 1
+/*
+	All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
+	The library I use will not work with address 255 initially and must be modified, see the README for details.
+	You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
+*/
+#define MODBUS_SLAVE_ADDR 255
 #define MODBUS_READ_CODE 3
 #define MODBUS_REQUEST1_START_ADDR 256
 #define MODBUS_REQUEST2_START_ADDR 280

--- a/Arduino-Version/My-Current-Seup/SOLAR_SEND_CC3/SOLAR_SEND_CC3.ino
+++ b/Arduino-Version/My-Current-Seup/SOLAR_SEND_CC3/SOLAR_SEND_CC3.ino
@@ -14,7 +14,7 @@
 #include <avr/wdt.h>        // Watchdog timer.
 
 /*
-	Pins to use for software serial for talking to the charge controller through the MAX3232.
+    Pins to use for software serial for talking to the charge controller through the MAX3232.
 */
 #define MAX3232_RX 2 // RX pin.
 #define MAX3232_TX 3 // TX pin.
@@ -36,9 +36,9 @@
     Modbus Constants
 */
 /*
-	All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
-	The library I use will not work with address 255 initially and must be modified, see the README for details.
-	You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
+    All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
+    The library I use will not work with address 255 initially and must be modified, see the README for details.
+    You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
 */
 #define MODBUS_SLAVE_ADDR 255
 #define MODBUS_READ_CODE 3
@@ -53,6 +53,8 @@
 #define THIS_NODE_ADDR 4                       // Address of this node.
 #define RF24_NETWORK_CHANNEL 90                // Channel the RF24 network should use.
 #define REQUEST_DELAY 2000                     // Delay in ms between requests to the charge controller over modbus.
+#define REQUEST_DELAY_JITTER_MIN 0             // Minimum delay jitter in ms between requests. (Avoid nodes constantly transmitting at the same time).
+#define REQUEST_DELAY_JITTER_MAX 200           // Maximum delay jitter in ms between requests. (Avoid nodes constantly transmitting at the same time).
 #define SETUP_FAIL_DELAY 2000                  // Delay when retrying setup tasks.
 #define SETUP_FINISH_DELAY 100*THIS_NODE_ADDR  // Delay after finishing setup. (Multiplied by address to to avoid interference on startup).
 
@@ -71,8 +73,8 @@ enum STATE {
 STATE state;
 
 unsigned long lastTime; // Last time isTime() was run and returned 1.
-
 uint16_t lastErrCnt; // Used to keep tract of modbus errors so we can compare to see how many new errors were generated.
+long requestDelayJitter; // Used to help make transmitters not constantly transmit at the same time.
 
 // Create the RF24 radio and network.
 RF24 radio(9, 10); // CE, CSN
@@ -130,7 +132,10 @@ void setup(){
     master.setTimeOut(MODBUS_MASTER_TIMEOUT);
     lastTime = millis();
     lastErrCnt = 0;
-    state = WAIT_REQUEST1; 
+    state = WAIT_REQUEST1;
+
+    randomSeed(analogRead(0));
+    requestDelayJitter = getNewDelayJitter();
 
     delay(SETUP_FINISH_DELAY);
 
@@ -139,10 +144,17 @@ void setup(){
 }
 
 /*
+    Generate a new random request delay jitter.
+*/
+long getNewDelayJitter(){
+    return random(REQUEST_DELAY_JITTER_MIN, REQUEST_DELAY_JITTER_MAX);
+}
+
+/*
     millis() Rollover safe time delay tracking.
 */
 uint8_t isTime(){
-    if(millis() - lastTime >= REQUEST_DELAY){
+    if(millis() - lastTime >= REQUEST_DELAY + requestDelayJitter){
         lastTime = millis();
         return 1;
     }
@@ -203,6 +215,8 @@ void loop(){
         RF24NetworkHeader header(RECEIVE_NODE_ADDR);
         network.write(header, &data, sizeof(data));
         delay(10);
+
+        requestDelayJitter = getNewDelayJitter();
 
         // Return to original state.
         state = WAIT_REQUEST1;

--- a/Arduino-Version/My-Current-Seup/SOLAR_SEND_CC3/SOLAR_SEND_CC3.ino
+++ b/Arduino-Version/My-Current-Seup/SOLAR_SEND_CC3/SOLAR_SEND_CC3.ino
@@ -1,5 +1,5 @@
 /*
-    Cole L - 19th November 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
+    Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
     
     This arduino is responsible for reporting the data from the third charge controller (BACK).
     
@@ -35,7 +35,12 @@
 /*
     Modbus Constants
 */
-#define MODBUS_SLAVE_ADDR 1
+/*
+	All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
+	The library I use will not work with address 255 initially and must be modified, see the README for details.
+	You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
+*/
+#define MODBUS_SLAVE_ADDR 255
 #define MODBUS_READ_CODE 3
 #define MODBUS_REQUEST1_START_ADDR 256
 #define MODBUS_REQUEST2_START_ADDR 280

--- a/Arduino-Version/My-Current-Seup/SOLAR_SEND_MISC/SOLAR_SEND_MISC.ino
+++ b/Arduino-Version/My-Current-Seup/SOLAR_SEND_MISC/SOLAR_SEND_MISC.ino
@@ -1,5 +1,5 @@
 /*
-    Cole L - 20th November 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
+    Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
 
     This arduino returns miscellaneous data from various sensors.
 
@@ -47,6 +47,8 @@
 #define THIS_NODE_ADDR 1                      // Address of this node.
 #define RF24_NETWORK_CHANNEL 90               // Channel the RF24 network should use.
 #define REQUEST_DELAY 2000                    // Delay in ms between requests to the charge controller over modbus.
+#define REQUEST_DELAY_JITTER_MIN 0             // Minimum delay jitter in ms between requests. (Avoid nodes constantly transmitting at the same time).
+#define REQUEST_DELAY_JITTER_MAX 200           // Maximum delay jitter in ms between requests. (Avoid nodes constantly transmitting at the same time).
 #define ADC_SAMPLES 30                        // Number of times to read the ADS1115 ADC to get an average. (Keep below 255)
 #define ADC_DELAY 2                           // Delay in ms between ADC readings to allow the ADC to settle.
 #define SETUP_FAIL_DELAY 2000                 // Delay when retrying setup tasks.
@@ -65,7 +67,8 @@ enum STATE {
 STATE state;
 
 unsigned long lastTime; // Last time isTime() was run and returned 1.
-const short int adcSamples = 30;
+long requestDelayJitter; // Used to help make transmitters not constantly transmit at the same time.
+
 // Create the RF24 radio and network
 RF24 radio(9, 10);    // CE, CSN
 RF24Network network(radio);
@@ -95,16 +98,16 @@ Package data;
 
 // Read the ADC data.
 void readADC(){
-    for(short int samples = 0; samples < adcSamples; samples++){
+    for(short int samples = 0; samples < ADC_SAMPLES; samples++){
         data.panelAmpsFrontA += ads1115.readADC_SingleEnded(FRONT_PANELS_A_ADS1115);
         data.panelAmpsFrontB += ads1115.readADC_SingleEnded(FRONT_PANELS_B_ADS1115);
         data.panelAmpsBack += ads1115.readADC_SingleEnded(BACK_PANELS_ADS1115);
         delay(ADC_DELAY); // Let the ADC settle down before the next sample.
     }
     // Average out the samples
-    data.panelAmpsFrontA = data.panelAmpsFrontA / (float)adcSamples;
-    data.panelAmpsFrontB = data.panelAmpsFrontB / (float)adcSamples;
-    data.panelAmpsBack = data.panelAmpsBack / (float)adcSamples;
+    data.panelAmpsFrontA = data.panelAmpsFrontA / (float)ADC_SAMPLES;
+    data.panelAmpsFrontB = data.panelAmpsFrontB / (float)ADC_SAMPLES;
+    data.panelAmpsBack = data.panelAmpsBack / (float)ADC_SAMPLES;
 }
 
 void setup(){
@@ -140,7 +143,10 @@ void setup(){
     network.begin(RF24_NETWORK_CHANNEL, THIS_NODE_ADDR);
     
     lastTime = millis();
-    state = WAIT_BME680; 
+    state = WAIT_BME680;
+
+	randomSeed(analogRead(0));
+    requestDelayJitter = getNewDelayJitter();
 
     delay(SETUP_FINISH_DELAY);
 
@@ -149,10 +155,17 @@ void setup(){
 }
 
 /*
+    Generate a new random request delay jitter.
+*/
+long getNewDelayJitter(){
+    return random(REQUEST_DELAY_JITTER_MIN, REQUEST_DELAY_JITTER_MAX);
+}
+
+/*
     millis() Rollover safe time delay tracking.
 */
 uint8_t isTime(){
-    if(millis() - lastTime >= REQUEST_DELAY){
+    if(millis() - lastTime >= REQUEST_DELAY + requestDelayJitter){
         lastTime = millis();
         return 1;
     }
@@ -189,6 +202,8 @@ void loop(){
         RF24NetworkHeader header(RECEIVE_NODE_ADDR);
         network.write(header, &data, sizeof(data));
         delay(10);
+
+		requestDelayJitter = getNewDelayJitter();
 
         // Return to original state
         state = WAIT_BME680;

--- a/Arduino-Version/My-Current-Seup/SOLAR_SEND_MISC/SOLAR_SEND_MISC.ino
+++ b/Arduino-Version/My-Current-Seup/SOLAR_SEND_MISC/SOLAR_SEND_MISC.ino
@@ -145,7 +145,7 @@ void setup(){
     lastTime = millis();
     state = WAIT_BME680;
 
-	randomSeed(analogRead(0));
+    randomSeed(analogRead(0));
     requestDelayJitter = getNewDelayJitter();
 
     delay(SETUP_FINISH_DELAY);
@@ -203,7 +203,7 @@ void loop(){
         network.write(header, &data, sizeof(data));
         delay(10);
 
-		requestDelayJitter = getNewDelayJitter();
+        requestDelayJitter = getNewDelayJitter();
 
         // Return to original state
         state = WAIT_BME680;

--- a/Arduino-Version/README.md
+++ b/Arduino-Version/README.md
@@ -6,30 +6,47 @@ Depending on the device you want to use, the connections will be a bit different
 
 ### Libraries
 The libraries this project uses are:
-- https://github.com/smarmengol/Modbus-Master-Slave-for-Arduino
+- https://github.com/smarmengol/Modbus-Master-Slave-for-Arduino (2 LINES MUST BE MODIFIED!)
 - https://github.com/nRF24/RF24 (Only for multiple controllers)
 - https://github.com/nRF24/RF24Network (Only for multiple controllers)
 - https://github.com/knolleary/pubsubclient (Only in my setup)
-- https://github.com/arduino-libraries/LiquidCrystal (Only in my setup)
+- https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library (Only in my setup)
 
+### Modbus library modifications
+The charge controllers will always respond to address 255. This is handy since some charge controllers appear to be using unexpected addresses. Unfortunately the library I am using for modbus does not initially support addresses above 247, so we need to make two small changes to it.
+
+Open the your arduino libraries folder and open the `Modbus-Master-Slave-for-Arduino-master` folder, then `ModbusRtu.h`.
+Search for `247` and you should find these two sections:
+
+![Code Fragment 1](https://user-images.githubusercontent.com/32819560/206619385-c340eb07-7897-4866-9a43-6654279cae7b.png)
+![Code Fragment 2](https://user-images.githubusercontent.com/32819560/206619495-d6839af4-b796-46eb-a575-aca30d9a14d0.png)
+
+In each section change the `247` to `255`. Save and restart your Arduino IDE.
+
+If you already know the address of your charge controller (it is probably `1`) you do not need to make these changes to the library and you should update the Arduino sketch with the appropriate address.
 
 ### Charge controller pinout
 Here is the pinout of the 6P6C connector on the charge controller as indicated by the modbus manual from SRNE.
+
 ![Controller Pinout](../Charge-Controller-Connector-Pinout.png)
 
 ### Charge controller cable to MAX3232
 Here is how I connect the charge controller to the MAX3232 breakout board. I used a male DB9 connector to plug into the breakout board and to connect it to the brad board, only the top row of contacts are used. My cable's wire colors may not match yours, check out 6P6C.jpg to compare yours against mine. (Note that the wire colors do not match their stereotypical roles. Blame whoever came up with the charge controller pinout)
+
 ![Charge controller to MAX3232 Breakout](./Single-Charge-Controller/Photos%20and%20Schematics/Cable-to-MAX3232-Breakout-Closeup.jpg)
 
 ### MAX3232 Voltage
 One thing to note is that the MAX3232 can be powered by 5V or 3.3V, so you might see them used interchangeably in the pictures.
 
 ## Arduino Nano
+
 ![Arduino Nano Overview](./Single-Charge-Controller/Photos%20and%20Schematics/Arduino-Nano-Overview.jpg)
 ![Arduino Nano Closeup](./Single-Charge-Controller/Photos%20and%20Schematics/Arduino-Nano-Closeup.jpg)
 
 ## ESP8266
+
 If you use the ESP8266 make sure you adjust the RX and TX pins for the software serial in the program. According to these pictures, the new values would be `MAX3232_RX = D1` and `MAX3232_TX = D2`.
+
 ![ESP8266 Overview](./Single-Charge-Controller/Photos%20and%20Schematics/ESP8266-Overview.jpg)
 ![ESP8266 Closeup](./Single-Charge-Controller/Photos%20and%20Schematics/ESP8266-Closeup.jpg)
 
@@ -42,4 +59,5 @@ This is the version I currently use for my solar system.
 As such, this version isn't really intended to be immediately plug and play. While the transmitter code will not need to be tweaked very much, the receiver is quite specific to my application.
 
 For my application I use three charge controllers. There are panels on the front of the house (CC1), side (CC2), and back (CC3). Each charge controller has an Arduino nano attached to it and there is an additional arduino for reporting some miscellaneous environment readings and direct amp readings. The Arduinos relay the information back to a receiver node (ESP8266) using RF24 modules. The transmitter then publishes the data over MQTT to a server which hosts it on a web interface. I've also included the PCB I'm using.
+
 ![PCB](./My-Current-Seup/PCB%20and%20Schematic/Assembled-PCB.jpg)

--- a/Arduino-Version/README.md
+++ b/Arduino-Version/README.md
@@ -6,14 +6,16 @@ Depending on the device you want to use, the connections will be a bit different
 
 ### Libraries
 The libraries this project uses are:
-- https://github.com/smarmengol/Modbus-Master-Slave-for-Arduino (2 LINES MUST BE MODIFIED!)
+- https://github.com/smarmengol/Modbus-Master-Slave-for-Arduino (**2 LINES MUST BE MODIFIED!**)
 - https://github.com/nRF24/RF24 (Only for multiple controllers)
 - https://github.com/nRF24/RF24Network (Only for multiple controllers)
 - https://github.com/knolleary/pubsubclient (Only in my setup)
 - https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library (Only in my setup)
+- https://github.com/Zanduino/BME680 (Only in my setup)
+- https://github.com/adafruit/Adafruit_ADS1X15 (Only in my setup)
 
-### Modbus library modifications
-The charge controllers will always respond to address 255. This is handy since some charge controllers appear to be using unexpected addresses. Unfortunately the library I am using for modbus does not initially support addresses above 247, so we need to make two small changes to it.
+#### Modbus library modifications
+The charge controllers will always respond to address 255. This is handy since some charge controllers appear to be using unknown addresses. Unfortunately the library I am using for modbus does not support addresses above 247, so we need to make two small changes to it.
 
 Open the your arduino libraries folder and open the `Modbus-Master-Slave-for-Arduino-master` folder, then `ModbusRtu.h`.
 Search for `247` and you should find these two sections:
@@ -23,7 +25,7 @@ Search for `247` and you should find these two sections:
 
 In each section change the `247` to `255`. Save and restart your Arduino IDE.
 
-If you already know the address of your charge controller (it is probably `1`) you do not need to make these changes to the library and you should update the Arduino sketch with the appropriate address.
+If you already know the address of your charge controller (it is probably `1`) you do not need to make these changes to the library and you should update the `MODBUS_SLAVE_ADDR` constant in the Arduino sketch with the appropriate address.
 
 ### Charge controller pinout
 Here is the pinout of the 6P6C connector on the charge controller as indicated by the modbus manual from SRNE.
@@ -31,7 +33,7 @@ Here is the pinout of the 6P6C connector on the charge controller as indicated b
 ![Controller Pinout](../Charge-Controller-Connector-Pinout.png)
 
 ### Charge controller cable to MAX3232
-Here is how I connect the charge controller to the MAX3232 breakout board. I used a male DB9 connector to plug into the breakout board and to connect it to the brad board, only the top row of contacts are used. My cable's wire colors may not match yours, check out 6P6C.jpg to compare yours against mine. (Note that the wire colors do not match their stereotypical roles. Blame whoever came up with the charge controller pinout)
+Here is how I connect the charge controller to the MAX3232 breakout board. I used a male DB9 connector to plug into the breakout board and to connect it to the brad board, only the top row of contacts are used. My cable's wire colors may not match yours, check out [6P6C-Connector.jpg](./6P6C-Connector.jpg) to compare yours against mine. (Note that the wire colors do not match their stereotypical roles. Blame whoever came up with the charge controller pinout)
 
 ![Charge controller to MAX3232 Breakout](./Single-Charge-Controller/Photos%20and%20Schematics/Cable-to-MAX3232-Breakout-Closeup.jpg)
 
@@ -56,8 +58,8 @@ You may want to use multiple charge controllers, in which case I would suggest h
 ## My current setup
 
 This is the version I currently use for my solar system.
-As such, this version isn't really intended to be immediately plug and play. While the transmitter code will not need to be tweaked very much, the receiver is quite specific to my application.
+As such, this version isn't really intended to be immediately plug and play. While the transmitter code is not too different, the receiver is quite specific to my application.
 
-For my application I use three charge controllers. There are panels on the front of the house (CC1), side (CC2), and back (CC3). Each charge controller has an Arduino nano attached to it and there is an additional arduino for reporting some miscellaneous environment readings and direct amp readings. The Arduinos relay the information back to a receiver node (ESP8266) using RF24 modules. The transmitter then publishes the data over MQTT to a server which hosts it on a web interface. I've also included the PCB I'm using.
+I use three charge controllers. There are panels on the front of the house (CC1), side (CC2), and back (CC3). Each charge controller has an Arduino nano attached to it and there is an additional arduino for reporting some miscellaneous sensor readings. The Arduinos send the information back to a receiver node (ESP8266) using RF24 modules. The transmitter then publishes the data over MQTT to a server which hosts it on a web interface. I've also included the PCB I'm using.
 
 ![PCB](./My-Current-Seup/PCB%20and%20Schematic/Assembled-PCB.jpg)

--- a/Arduino-Version/Single-Charge-Controller/SOLAR_SINGLE_CC/SOLAR_SINGLE_CC.ino
+++ b/Arduino-Version/Single-Charge-Controller/SOLAR_SINGLE_CC/SOLAR_SINGLE_CC.ino
@@ -2,18 +2,18 @@
     Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
     
     This is an example to retrieve data from a single charge controller. All this program does is print the data to the console.
-	This should give you enough information on how to read the values so you can do more exciting stuff with the data.
-	I would suggest looking into setting up an MQTT server so you can view the data on other devices.
-	
-	See images and schematic for wiring details.
+    This should give you enough information on how to read the values so you can do more exciting stuff with the data.
+    I would suggest looking into setting up an MQTT server so you can view the data on other devices.
+    
+    See images and schematic for wiring details.
 */
 
 #include <ModbusRtu.h>      // Modbus for talking to charge controller.
 #include <SoftwareSerial.h> // Software serial for modbus.
-#include <math.h>			// Used for pow() when deceiphering fault data.
+#include <math.h>           // Used for pow() when deceiphering fault data.
 
 /*
-	Pins to use for software serial for talking to the charge controller through the MAX3232.
+    Pins to use for software serial for talking to the charge controller through the MAX3232.
 */
 #define MAX3232_RX 2 // RX pin. If following my ESP8266 instructions use D1 or 5.
 #define MAX3232_TX 3 // TX pin. If following my ESP8266 instructions use D2 or 4.
@@ -29,9 +29,9 @@
     Modbus Constants
 */
 /*
-	All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
-	The library I use will not work with address 255 initially and must be modified, see the README for details.
-	You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
+    All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
+    The library I use will not work with address 255 initially and must be modified, see the README for details.
+    You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
 */
 #define MODBUS_SLAVE_ADDR 255
 #define MODBUS_READ_CODE 3
@@ -60,8 +60,8 @@ const char* chargeModes[7]={
 };
 
 /*
-	Array of fault codes.
-	These are all the possible faults the charge controller can indicate.
+    Array of fault codes.
+    These are all the possible faults the charge controller can indicate.
 */
 const char* faultCodes[15] = {
     "Charge MOS short circuit",     // (16384 | 01000000 00000000)
@@ -96,7 +96,6 @@ enum STATE {
 STATE state;
 
 unsigned long lastTime; // Last time isTime() was run and returned 1.
-
 uint16_t lastErrCnt; // Used to keep tract of modbus errors so we can compare to see how many new errors were generated.
 
 // Create software serial for communicating with Charge Controller.
@@ -145,14 +144,14 @@ void setup(){
     lastErrCnt = 0;
     state = WAIT_REQUEST1;
 
-	// Make an array of pointers to make it easier to access the charge controller data.
+    // Make an array of pointers to make it easier to access the charge controller data.
     // Initialize pointers array for request1 registers.
     for(int i = 0; i<NUM_REGISTERS_REQUEST1; i++){
-		chargeControllerRegisterData[i] = &chargeControllerNodeData.request1[i];
+        chargeControllerRegisterData[i] = &chargeControllerNodeData.request1[i];
     }
     // Initialize pointers array for request2 registers.
     for(int i = 0; i<NUM_REGISTERS_REQUEST2; i++){
-		chargeControllerRegisterData[i + NUM_REGISTERS_REQUEST1] = &chargeControllerNodeData.request2[i];
+        chargeControllerRegisterData[i + NUM_REGISTERS_REQUEST1] = &chargeControllerNodeData.request2[i];
     }
 
     delay(SETUP_FINISH_DELAY);
@@ -177,194 +176,194 @@ int getRealTemp(int temp){
 }
 
 /*
-	Print all the charge controller data to the serial monitor.
+    Print all the charge controller data to the serial monitor.
 */
 void printAllData(){
-	Serial.println(F("------------- Real Time Data -------------"));
+    Serial.println(F("------------- Real Time Data -------------"));
 
-	// Print the charging mode of the charge controller:
-	int loadOffset = *chargeControllerRegisterData[32] > 6 ? 32768 : 0;
-	Serial.print(F("Charging Mode:\t\t\t"));
-	Serial.println(chargeModes[*chargeControllerRegisterData[32] - loadOffset]);
+    // Print the charging mode of the charge controller:
+    int loadOffset = *chargeControllerRegisterData[32] > 6 ? 32768 : 0;
+    Serial.print(F("Charging Mode:\t\t\t"));
+    Serial.println(chargeModes[*chargeControllerRegisterData[32] - loadOffset]);
 
-	// Print the battery state of charge:
-	Serial.print(F("Battery SOC:\t\t\t"));
-	Serial.print(*chargeControllerRegisterData[0]);
-	Serial.println(F("%"));
+    // Print the battery state of charge:
+    Serial.print(F("Battery SOC:\t\t\t"));
+    Serial.print(*chargeControllerRegisterData[0]);
+    Serial.println(F("%"));
 
-	// Print the battery voltage:
-	Serial.print(F("Battery Voltage:\t\t"));
-	Serial.print((*chargeControllerRegisterData[1]*0.1));
-	Serial.println(F("V"));
+    // Print the battery voltage:
+    Serial.print(F("Battery Voltage:\t\t"));
+    Serial.print((*chargeControllerRegisterData[1]*0.1));
+    Serial.println(F("V"));
 
-	// Print the battery charge current:
-	Serial.print(F("Battery Charge Current:\t\t"));
-	Serial.print((*chargeControllerRegisterData[2]*0.01));
-	Serial.println(F("A"));
+    // Print the battery charge current:
+    Serial.print(F("Battery Charge Current:\t\t"));
+    Serial.print((*chargeControllerRegisterData[2]*0.01));
+    Serial.println(F("A"));
 
-	// Print the controller temperature:
-	Serial.print(F("Controller Temperature:\t\t"));
-	Serial.print(getRealTemp(*chargeControllerRegisterData[3] >> 8));
-	Serial.println(F("*C"));
+    // Print the controller temperature:
+    Serial.print(F("Controller Temperature:\t\t"));
+    Serial.print(getRealTemp(*chargeControllerRegisterData[3] >> 8));
+    Serial.println(F("*C"));
 
-	// Print the battery temperature:
-	Serial.print(F("Battery Temperature:\t\t"));
-	Serial.print(getRealTemp(*chargeControllerRegisterData[3] & 0xFF));
-	Serial.println(F("*C"));
+    // Print the battery temperature:
+    Serial.print(F("Battery Temperature:\t\t"));
+    Serial.print(getRealTemp(*chargeControllerRegisterData[3] & 0xFF));
+    Serial.println(F("*C"));
 
-	// Print the load voltage:
-	Serial.print(F("Load Voltage:\t\t\t"));
-	Serial.print((*chargeControllerRegisterData[4]*0.1));
-	Serial.println(F("V"));
+    // Print the load voltage:
+    Serial.print(F("Load Voltage:\t\t\t"));
+    Serial.print((*chargeControllerRegisterData[4]*0.1));
+    Serial.println(F("V"));
 
-	// Print the load current:
-	Serial.print(F("Load Current:\t\t\t"));
-	Serial.print((*chargeControllerRegisterData[5]*0.01));
-	Serial.println(F("A"));
+    // Print the load current:
+    Serial.print(F("Load Current:\t\t\t"));
+    Serial.print((*chargeControllerRegisterData[5]*0.01));
+    Serial.println(F("A"));
 
-	// Print the load power:
-	Serial.print(F("Load Power:\t\t\t"));
-	Serial.print(*chargeControllerRegisterData[6]);
-	Serial.println(F("W"));
+    // Print the load power:
+    Serial.print(F("Load Power:\t\t\t"));
+    Serial.print(*chargeControllerRegisterData[6]);
+    Serial.println(F("W"));
 
-	// Print the panel volts:
-	Serial.print(F("Panel Volts:\t\t\t"));
-	Serial.print((*chargeControllerRegisterData[7]*0.1));
-	Serial.println(F("V"));
+    // Print the panel volts:
+    Serial.print(F("Panel Volts:\t\t\t"));
+    Serial.print((*chargeControllerRegisterData[7]*0.1));
+    Serial.println(F("V"));
 
-	// Print the panel amps:
-	Serial.print(F("Panel Amps:\t\t\t"));
-	Serial.print((*chargeControllerRegisterData[8]*0.01));
-	Serial.println(F("A"));
+    // Print the panel amps:
+    Serial.print(F("Panel Amps:\t\t\t"));
+    Serial.print((*chargeControllerRegisterData[8]*0.01));
+    Serial.println(F("A"));
 
-	// Print the panel power:
-	Serial.print(F("Panel Power: \t\t\t"));
-	Serial.print(*chargeControllerRegisterData[9]);
-	Serial.println(F("W"));
+    // Print the panel power:
+    Serial.print(F("Panel Power: \t\t\t"));
+    Serial.print(*chargeControllerRegisterData[9]);
+    Serial.println(F("W"));
 
-	Serial.println("--------------- DAILY DATA ---------------");
+    Serial.println("--------------- DAILY DATA ---------------");
 
-	// Print the daily battery minimum voltage:
-	Serial.print(F("Battery Minimum Voltage:\t"));
-	Serial.print((*chargeControllerRegisterData[11]*0.1));
-	Serial.println(F("V"));
+    // Print the daily battery minimum voltage:
+    Serial.print(F("Battery Minimum Voltage:\t"));
+    Serial.print((*chargeControllerRegisterData[11]*0.1));
+    Serial.println(F("V"));
 
-	// Print the daily battery minimum voltage:
-	Serial.print(F("Battery Maximum Voltage:\t"));
-	Serial.print((*chargeControllerRegisterData[12]*0.1));
-	Serial.println(F("V"));
+    // Print the daily battery minimum voltage:
+    Serial.print(F("Battery Maximum Voltage:\t"));
+    Serial.print((*chargeControllerRegisterData[12]*0.1));
+    Serial.println(F("V"));
 
-	// Print the daily maximum charge current:
-	Serial.print(F("Maximum Charge Current:\t\t"));
-	Serial.print((*chargeControllerRegisterData[13]*0.01));
-	Serial.println(F("A"));
+    // Print the daily maximum charge current:
+    Serial.print(F("Maximum Charge Current:\t\t"));
+    Serial.print((*chargeControllerRegisterData[13]*0.01));
+    Serial.println(F("A"));
 
-	// Print the daily maximum load current:
-	Serial.print(F("Maximum Load Discharge Current:\t"));
-	Serial.print((*chargeControllerRegisterData[14]*0.01));
-	Serial.println(F("A"));
+    // Print the daily maximum load current:
+    Serial.print(F("Maximum Load Discharge Current:\t"));
+    Serial.print((*chargeControllerRegisterData[14]*0.01));
+    Serial.println(F("A"));
 
-	// Print the daily maximum charge power: 
-	Serial.print(F("Maximum Charge Power:\t\t"));
-	Serial.print(*chargeControllerRegisterData[15]);
-	Serial.println(F("W"));
+    // Print the daily maximum charge power: 
+    Serial.print(F("Maximum Charge Power:\t\t"));
+    Serial.print(*chargeControllerRegisterData[15]);
+    Serial.println(F("W"));
 
-	// Print the daily maximum load power: 
-	Serial.print(F("Maximum Load Discharge Power:\t"));
-	Serial.print(*chargeControllerRegisterData[16]);
-	Serial.println(F("W"));
+    // Print the daily maximum load power: 
+    Serial.print(F("Maximum Load Discharge Power:\t"));
+    Serial.print(*chargeControllerRegisterData[16]);
+    Serial.println(F("W"));
 
-	// Print the daily charge amp hours:
-	Serial.print(F("Charge Amp Hours:\t\t"));
-	Serial.print(*chargeControllerRegisterData[17]);
-	Serial.println(F("Ah"));
+    // Print the daily charge amp hours:
+    Serial.print(F("Charge Amp Hours:\t\t"));
+    Serial.print(*chargeControllerRegisterData[17]);
+    Serial.println(F("Ah"));
 
-	// Print the daily load amp hours:
-	Serial.print(F("Load Amp Hours:\t\t\t"));
-	Serial.print(*chargeControllerRegisterData[18]);
-	Serial.println(F("Ah"));
+    // Print the daily load amp hours:
+    Serial.print(F("Load Amp Hours:\t\t\t"));
+    Serial.print(*chargeControllerRegisterData[18]);
+    Serial.println(F("Ah"));
 
-	// Print the daily charge power:
-	Serial.print(F("Charge Power:\t\t\t"));
-	Serial.print((*chargeControllerRegisterData[19]*0.001));
-	Serial.println(F("KWh"));
+    // Print the daily charge power:
+    Serial.print(F("Charge Power:\t\t\t"));
+    Serial.print((*chargeControllerRegisterData[19]*0.001));
+    Serial.println(F("KWh"));
 
-	// Print the daily load power:
-	Serial.print(F("Load Power:\t\t\t"));
-	Serial.print((*chargeControllerRegisterData[20]*0.001));
-	Serial.println(F("KWh"));
+    // Print the daily load power:
+    Serial.print(F("Load Power:\t\t\t"));
+    Serial.print((*chargeControllerRegisterData[20]*0.001));
+    Serial.println(F("KWh"));
 
-	Serial.println(F("------------- LIFETIME DATA --------------"));
+    Serial.println(F("------------- LIFETIME DATA --------------"));
 
-	// Print the number of days operational:
-	Serial.print(F("Days Operational:\t\t"));
-	Serial.print(*chargeControllerRegisterData[21]);
-	Serial.println(F("Days"));
+    // Print the number of days operational:
+    Serial.print(F("Days Operational:\t\t"));
+    Serial.print(*chargeControllerRegisterData[21]);
+    Serial.println(F("Days"));
 
-	// Print the number of times batteries were over discharged:
-	Serial.print(F("Times Over Discharged:\t\t"));
-	Serial.println(*chargeControllerRegisterData[22]);
+    // Print the number of times batteries were over discharged:
+    Serial.print(F("Times Over Discharged:\t\t"));
+    Serial.println(*chargeControllerRegisterData[22]);
 
-	// Print the number of times batteries were fully charges:
-	Serial.print(F("Times Fully Charged:\t\t"));
-	Serial.println(*chargeControllerRegisterData[23]);
+    // Print the number of times batteries were fully charges:
+    Serial.print(F("Times Fully Charged:\t\t"));
+    Serial.println(*chargeControllerRegisterData[23]);
 
-	// Print the cumulative amp hours:
-	Serial.print(F("Cumulative Amp Hours:\t\t"));
-	Serial.print(((*chargeControllerRegisterData[24]*65536 + *chargeControllerRegisterData[25])*0.001));
-	Serial.println(F("KAh"));
+    // Print the cumulative amp hours:
+    Serial.print(F("Cumulative Amp Hours:\t\t"));
+    Serial.print(((*chargeControllerRegisterData[24]*65536 + *chargeControllerRegisterData[25])*0.001));
+    Serial.println(F("KAh"));
 
-	// Print the cumulative load amp hours:
-	Serial.print(F("Load Amp Hours:\t\t\t"));
-	Serial.print(((*chargeControllerRegisterData[26]*65536 + *chargeControllerRegisterData[27])*0.001));
-	Serial.println(F("KAh"));
+    // Print the cumulative load amp hours:
+    Serial.print(F("Load Amp Hours:\t\t\t"));
+    Serial.print(((*chargeControllerRegisterData[26]*65536 + *chargeControllerRegisterData[27])*0.001));
+    Serial.println(F("KAh"));
 
-	// Print the cumulative power hours:
-	Serial.print(F("Cumulative Power:\t\t"));
-	Serial.print(((*chargeControllerRegisterData[28]*65536 + *chargeControllerRegisterData[29])*0.001));
-	Serial.println(F("KWh"));
+    // Print the cumulative power hours:
+    Serial.print(F("Cumulative Power:\t\t"));
+    Serial.print(((*chargeControllerRegisterData[28]*65536 + *chargeControllerRegisterData[29])*0.001));
+    Serial.println(F("KWh"));
 
-	// Print the cumulative load amp hours:
-	Serial.print(F("Load Power:\t\t\t"));
-	Serial.print(((*chargeControllerRegisterData[30]*65536 + *chargeControllerRegisterData[31])*0.001));
-	Serial.println(F("KWh"));
+    // Print the cumulative load amp hours:
+    Serial.print(F("Load Power:\t\t\t"));
+    Serial.print(((*chargeControllerRegisterData[30]*65536 + *chargeControllerRegisterData[31])*0.001));
+    Serial.println(F("KWh"));
 
-	Serial.println(F("--------------- FAULT DATA ---------------"));
+    Serial.println(F("--------------- FAULT DATA ---------------"));
 
-	// Determine if there are any faults / what they mean.
-	String faults = "- None :)";
-	int faultID = *chargeControllerRegisterData[34];
-	if(faultID != 0){
-		if(faultID > 16384 || faultID < 0){
-			faults = "- Invalid fault code!";
-		}
-		else{
-			faults = "";
-			int count = 0;
-			int faultCount = 0;
-			while(faultID != 0){
-				if(faultID >= pow(2, 15-count)){
-					// If there is more than one error, make a new line.
-					if(faultCount > 0){
-						faults += "\n";
-					}
-					faults += "- ";
-					faults += faultCodes[count-1];
-					faultID -= pow(2, 15-count);
-					faultCount++;
-				}
-				count++;
-			}
-		}
-	}
-	// Print the faults
-	Serial.println(F("Faults:"));
-	Serial.println(faults);
+    // Determine if there are any faults / what they mean.
+    String faults = "- None :)";
+    int faultID = *chargeControllerRegisterData[34];
+    if(faultID != 0){
+        if(faultID > 16384 || faultID < 0){
+            faults = "- Invalid fault code!";
+        }
+        else{
+            faults = "";
+            int count = 0;
+            int faultCount = 0;
+            while(faultID != 0){
+                if(faultID >= pow(2, 15-count)){
+                    // If there is more than one error, make a new line.
+                    if(faultCount > 0){
+                        faults += "\n";
+                    }
+                    faults += "- ";
+                    faults += faultCodes[count-1];
+                    faultID -= pow(2, 15-count);
+                    faultCount++;
+                }
+                count++;
+            }
+        }
+    }
+    // Print the faults
+    Serial.println(F("Faults:"));
+    Serial.println(faults);
 
-	// Print the raw fault data
-	Serial.print(F("RAW Fault Data:\t\t\t"));
-	Serial.println(*chargeControllerRegisterData[34]);
-	Serial.println(F("------------------------------------------\n"));
+    // Print the raw fault data
+    Serial.print(F("RAW Fault Data:\t\t\t"));
+    Serial.println(*chargeControllerRegisterData[34]);
+    Serial.println(F("------------------------------------------\n"));
 }
 
 void loop(){
@@ -403,13 +402,13 @@ void loop(){
         chargeControllerNodeData.modbusErrDiff = (uint16_t) (master.getErrCnt() - lastErrCnt);
         lastErrCnt = master.getErrCnt();
 
-		// Indicate if there was a problem talking to the charge controller.
-		if(chargeControllerNodeData.modbusErrDiff > 0){
-			Serial.println(F("Error when trying to communicate with the charge controller."));
-		}
+        // Indicate if there was a problem talking to the charge controller.
+        if(chargeControllerNodeData.modbusErrDiff > 0){
+            Serial.println(F("Error when trying to communicate with the charge controller."));
+        }
 
-		// As an example, print out all the data.
-		printAllData();
+        // As an example, print out all the data.
+        printAllData();
 
         // Return to original state.
         state = WAIT_REQUEST1;

--- a/Arduino-Version/Single-Charge-Controller/SOLAR_SINGLE_CC/SOLAR_SINGLE_CC.ino
+++ b/Arduino-Version/Single-Charge-Controller/SOLAR_SINGLE_CC/SOLAR_SINGLE_CC.ino
@@ -1,5 +1,5 @@
 /*
-    Cole L - 20th November 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
+    Cole L - 24th December 2022 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
     
     This is an example to retrieve data from a single charge controller. All this program does is print the data to the console.
 	This should give you enough information on how to read the values so you can do more exciting stuff with the data.
@@ -15,8 +15,8 @@
 /*
 	Pins to use for software serial for talking to the charge controller through the MAX3232.
 */
-#define MAX3232_RX 2 // RX pin. If following my ESP8266 instructions use D1.
-#define MAX3232_TX 3 // TX pin. If following my ESP8266 instructions use D2.
+#define MAX3232_RX 2 // RX pin. If following my ESP8266 instructions use D1 or 5.
+#define MAX3232_TX 3 // TX pin. If following my ESP8266 instructions use D2 or 4.
 
 /*
     I had issues with the transmitter's Serial buffers running out of room when receiving more than 29 registers at once 
@@ -28,7 +28,12 @@
 /*
     Modbus Constants
 */
-#define MODBUS_SLAVE_ADDR 1
+/*
+	All charge controllers will respond to address 255 no matter what their actual address is, this is useful if you do not know what address to use.
+	The library I use will not work with address 255 initially and must be modified, see the README for details.
+	You can try using 1 here instead of 255 if you don't want to make changes to the library, but it is not guaranteed to work.
+*/
+#define MODBUS_SLAVE_ADDR 255
 #define MODBUS_READ_CODE 3
 #define MODBUS_REQUEST1_START_ADDR 256
 #define MODBUS_REQUEST2_START_ADDR 280

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Read data from SRNE solar charge controllers via modbus over RS232.
 This repository contains two setups for reading data from SRNE solar charge controllers. One for a raspberry pi and another based on an arduino network.
 
 ### Raspberry Pi Version
-Please note that all the raspberry pi version does is fetch the data from the controller and print it to screen. If you encounter any issues with it let me know, I have not been really been able to test it recently since I've switched to the arduino version.
+All the raspberry pi version does is fetch the data from the controller and print it to screen. If you encounter any issues with it let me know, I have not been really been able to test it recently since I've switched to the arduino version.
 
 ### Arduino Version
 This is the version I actively use and have spent the most time on.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is the version I actively use and have spent the most time on.
 I have included some examples to make getting started easier, I've also included my current setup for reference.
 There is a much more detailed README file in that directory.
 I also designed a custom PCB (PCB files are included):
+
 ![PCB](./Arduino-Version/My-Current-Seup/PCB%20and%20Schematic/Assembled-PCB.jpg)
 
 ### Other notes


### PR DESCRIPTION
- Fix issue to handle case where some charge controllers may use an unknown address that isn't 1. If we use address 255 then all charge controllers will respond regardless of their actual address. Add instructions for how to patch the modbus library to allow address 255.
- Fix bug in my current setup where LCD would refresh slowly if MQTT server is unreachable.
- Add random delay to my current setup to avoid 2 nodes transmitting at the same time repeatedly.
- Fix formatting inconsistencies between files.
- Update readme files.