### PR TITLE
Fix custom web-ui modal X button behavior.

### DIFF
--- a/My-Current-Setup/Web-Interface/index.html
+++ b/My-Current-Setup/Web-Interface/index.html
@@ -161,7 +161,7 @@
 								<div class="modal-content custom-modal-light">
 									<div class="modal-header custom-modal-header-light">
 										<h1 class="modal-title fs-5 text-light" id="15AMPConfirmModalLabel">Are you sure?</h1>
-										<button type="button" class="btn-close custom-btn-close-light" data-bs-dismiss="modal" aria-label="Close"></button>
+										<button type="button" class="btn-close custom-btn-close-light" id="15AMPModalX" data-bs-dismiss="modal" aria-label="Close"></button>
 									</div>
 									<div class="modal-body">
 										<p class="text-light">Are you sure you want to turn off the 15 AMP Plug?</p>
@@ -236,7 +236,7 @@
 								<div class="modal-content custom-modal-light">
 									<div class="modal-header custom-modal-header-light">
 										<h1 class="modal-title fs-5 text-light" id="20AMPConfirmModalLabel">Are you sure?</h1>
-										<button type="button" class="btn-close custom-btn-close-light" data-bs-dismiss="modal" aria-label="Close"></button>
+										<button type="button" class="btn-close custom-btn-close-light" id="20AMPModalX" data-bs-dismiss="modal" aria-label="Close"></button>
 									</div>
 									<div class="modal-body">
 										<p class="text-light">Are you sure you want to turn off the 20 AMP Plug?</p>

--- a/My-Current-Setup/Web-Interface/index.js
+++ b/My-Current-Setup/Web-Interface/index.js
@@ -53,6 +53,9 @@ const confirmElements = [undefined, undefined];
 // "Cancel" buttons of each confirmation modal.
 const cancelElements = [undefined, undefined];
 
+// "X" buttons of each confirmation modal.
+const xElements = [undefined, undefined];
+
 // UI plug switch is locked to it's current state and will not be updated by MQTT until unlocked.
 // Used to prevent the switch from switching back if we get an update just as someone toggles the switch.
 const lockedSwitch = [false, false, false, false, false];
@@ -644,6 +647,7 @@ function setupPlugs() {
       confirmElements[index].addEventListener("click", function () {
         togglePlug(index, false);
       });
+
       cancelElements[index] = document.getElementById(
         `${plugTopics[index]}Cancel`
       );
@@ -652,9 +656,17 @@ function setupPlugs() {
         lockedSwitch[index] = false;
       });
 
+	  xElements[index] = document.getElementById(
+        `${plugTopics[index]}ModalX`
+      );
+      xElements[index].addEventListener("click", function () {
+        plugElements[index].checked = true;
+        lockedSwitch[index] = false;
+      });
+
       // Only show the modal when turning the plug off.
       plugElements[index].addEventListener("click", function () {
-        if (plugElements[index].checked) {
+        if (plugElements[index].checked) { // Pressing toggle to trigger this flips the switch, invert logic.
           togglePlug(index, true);
         } else {
           lockedSwitch[index] = true;

--- a/My-Current-Setup/Web-Interface/index.js
+++ b/My-Current-Setup/Web-Interface/index.js
@@ -1,4 +1,4 @@
-// Cole L - 1st May 2023 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
+// Cole L - 6th May 2023 - https://github.com/cole8888/SRNE-Solar-Charge-Controller-Monitor
 // Originally based on https://github.com/fabaff/mqtt-panel
 
 const host = "192.168.2.50";


### PR DESCRIPTION
The plug switch confirmation modal X button would not revert the state of the switch to it's original position or unlock it to allow the stats to be updated afterwards.